### PR TITLE
Add dsh-browser, modsearch, and dsh-genui

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dsh is a developer preview and the team promises compatibility-breaking changes.
 
 ## Registry
 
-31 entries. Data updated 2026-08-13.
+35 entries. Data updated 2026-08-14.
 
 ### Bundles
 
@@ -50,8 +50,10 @@ Cordis plugins activated through patch rows in a bundle or profile.
 | dsh-agent-teams | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | - | AgentTeams plugin: coordinate teams of subagents from the web UI | 0.1.0-rc.5 (2026-08-13) |
 | dsh-at-file | [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | - | Codex-style @file mentions in the composer: search workspace files and attach their contents to prompts | 0.1.0-rc.5 (2026-08-13) |
 | dsh-better-sidebar | [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | [`dsh-better-sidebar`](https://www.npmjs.com/package/dsh-better-sidebar) | Full sidebar workbench with file rendering/editing, terminal, Git, and subagents; third-party extensions can register new tabs | 0.1.0-rc.5 (2026-08-13) |
+| dsh-browser | [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser) | - | Chrome sidebar plugin that lets dsh operate the browser directly, without vision. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-cc-tui | [ccch1mneyyy/dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) | [`dsh-cc-tui`](https://www.npmjs.com/package/dsh-cc-tui) | Claude Code-style fullscreen terminal UI: streaming thinking, double-Esc rewind, context progress bar, and TPS meter over the headless runner | 0.1.0-rc.5 (2026-08-13) |
 | dsh-custom-tool | [omdsh-dev/dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | - | Create and manage sandboxed JavaScript tools with a Monaco editor and a model-driven tool lifecycle | 0.1.0-rc.5 (2026-08-13) |
+| dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | - | Renders interactive UI components inline in assistant replies via the dsh-ui fence: layout, charts, plots, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-notification | [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) | - | Desktop notifications for turn completions, with per-outcome controls and include/exclude keyword rules | 0.1.0-rc.5 (2026-08-13) |
 | dsh-open-in-vscode | [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | - | Open workspace directories in VS Code directly from the web GUI | 0.1.0-rc.5 (2026-08-13) |
 | dsh-openpencil | [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | [`@zseven-w/dsh-openpencil`](https://www.npmjs.com/package/@zseven-w/dsh-openpencil) | OpenPencil design preview and editing inside the web UI | 0.1.0-rc.5 (2026-08-13) |
@@ -63,6 +65,7 @@ Cordis plugins activated through patch rows in a bundle or profile.
 | dsh-web-ui | [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | - | Plugin and skin collection for the dsh Web UI: task board, git graph, right-side panel, remote mobile UI, live token stats, and a skin center that routes around the theme-persistence gap | 0.1.0-rc.5 (2026-08-13) |
 | dsh-workflow | [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | - | Workflow layer that upgrades one-shot multi-agent dispatch into savable, governable, observable, and resumable workflows | 0.1.0-rc.5 (2026-08-13) |
 | modlens | [liustack/modlens](https://github.com/liustack/modlens) | [`@liustack/modlens`](https://www.npmjs.com/package/@liustack/modlens) | Vision plugin for text-only models: image understanding bridged into the harness via a dsh.bundle patch layer, shipping a modlens skill alongside | 0.1.0-rc.5 (2026-08-13) |
+| modsearch | [liustack/modsearch](https://github.com/liustack/modsearch) | [`@liustack/modsearch`](https://www.npmjs.com/package/@liustack/modsearch) | Web plugin for dsh that gives a text-only model the web: search, X, and any page as structured evidence. | 0.1.0-rc.6 (2026-08-14) |
 | whale-girl | [vlln/whale-girl](https://github.com/vlln/whale-girl) | - | Desktop-pet companion for the web GUI (QQ-pet style): draggable, feedable, levels up with session activity; migrated from the removed .dsh-plugin format to dsh.bundle | 0.1.0-rc.5 (2026-08-13) |
 
 ### Skills
@@ -85,6 +88,14 @@ UI skins. Note: third-party theme ids do not yet persist to settings; most skins
 | Name | Repo | npm | Description | Verified against |
 |---|---|---|---|---|
 | dsh-deep-whale | [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale/tree/HEAD/maid-atelier) | - | Whale-girl skin series for the web UI; maid-atelier ships as a dsh.bundle package installed from a local clone (CC BY-NC-SA, non-commercial) | 0.1.0-rc.5 (2026-08-13) |
+
+### Tools
+
+Developer tooling around dsh.
+
+| Name | Repo | npm | Description | Verified against |
+|---|---|---|---|---|
+| create-dsh-plugin | [whyihaveyou/dsh-suite](https://github.com/whyihaveyou/dsh-suite/tree/HEAD/packages/create-dsh-plugin) | [`create-dsh-plugin`](https://www.npmjs.com/package/create-dsh-plugin) | Scaffold a DeepSeek Harness plugin in seconds: tool, events, and webui templates with next-tag version pinning and a built-in --verify smoke test. | 0.1.0-rc.6 (2026-08-14) |
 
 ## Add your plugin
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema.json",
-  "updated": "2026-08-13",
+  "updated": "2026-08-14",
   "plugins": [
     {
       "name": "dsh-base",
@@ -358,6 +358,53 @@
       "lastVerified": "2026-08-13",
       "verifiedAgainst": "0.1.0-rc.5",
       "status": "verified"
+    },
+    {
+      "name": "dsh-browser",
+      "repo": "Lum1104/dsh-browser",
+      "description": "Chrome sidebar plugin that lets dsh operate the browser directly, without vision.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-14",
+      "lastVerified": "2026-08-14",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified"
+    },
+    {
+      "name": "modsearch",
+      "repo": "liustack/modsearch",
+      "description": "Web plugin for dsh that gives a text-only model the web: search, X, and any page as structured evidence.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-14",
+      "lastVerified": "2026-08-14",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "npm": "@liustack/modsearch"
+    },
+    {
+      "name": "dsh-genui",
+      "repo": "omdsh-dev/dsh-genui",
+      "description": "Renders interactive UI components inline in assistant replies via the dsh-ui fence: layout, charts, plots, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-14",
+      "lastVerified": "2026-08-14",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified"
+    },
+    {
+      "name": "create-dsh-plugin",
+      "repo": "whyihaveyou/dsh-suite",
+      "path": "packages/create-dsh-plugin",
+      "description": "Scaffold a DeepSeek Harness plugin in seconds: tool, events, and webui templates with next-tag version pinning and a built-in --verify smoke test.",
+      "category": "tool",
+      "official": false,
+      "added": "2026-08-14",
+      "lastVerified": "2026-08-14",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "npm": "create-dsh-plugin"
     }
   ]
 }

--- a/data/rejected.json
+++ b/data/rejected.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-08-13",
+  "updated": "2026-08-14",
   "rejected": [
     {
       "repo": "0xsline/awesome-deepseek-harness",
@@ -69,11 +69,6 @@
     {
       "repo": "LaplaceYoung/oh-my-dsh",
       "reason": "700+ batch-generated plugin stubs, no dsh.bundle anywhere; template spam",
-      "date": "2026-08-13"
-    },
-    {
-      "repo": "Lum1104/dsh-browser",
-      "reason": "no dsh.bundle/npm/SKILL.md install path (hand-written cordis config); bridge package squats @deepseek-ai scope",
       "date": "2026-08-13"
     },
     {


### PR DESCRIPTION
Community plugins for dsh, verified against 0.1.0-rc.6.

- dsh-browser (Lum1104/dsh-browser)
- modsearch (liustack/modsearch)
- dsh-genui (omdsh-dev/dsh-genui)
- create-dsh-plugin (whyihaveyou/dsh-suite scaffold)

Also removes Lum1104/dsh-browser from rejected.json: the repo now ships a dsh.bundle patch and an install path.