### PR TITLE
Add riffkit/skill (category: skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 1028 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 1029 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -72,7 +72,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-926 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-14.
+926 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
 ### Web UI
 
@@ -1230,6 +1230,7 @@ Anthropic-format `SKILL.md` units; dsh discovers them from its skill roots (no n
 | dsh-plugin-audit | 0 | [wefio/dsh-plugin-audit](https://github.com/wefio/dsh-plugin-audit) | Community DeepSeek Harness plugin. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-plugin-dev-skill | 0 | [green-dalii/dsh-plugin-dev-skill](https://github.com/green-dalii/dsh-plugin-dev-skill) | A skill pack that enables any agent to develop DeepSeek Harness (DSH) plugins correctly, efficiently, and in accordance with the official conventions. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-plugin-development-ray | 0 | [RayYeung1989/dsh-plugin-development](https://github.com/RayYeung1989/dsh-plugin-development) | 通用 dsh 插件开发 Skill：任何 agent 工具加载即会开发符合 DeepSeek Harness 的 dsh 插件 (Agent-tool-agnostic SKILL.md for developing DeepSeek Harness dsh plugins) | 0.1.0-rc.6 (2026-08-14) |
+| riffkit | - | [riffkit/skill](https://github.com/riffkit/skill/tree/HEAD/riffkit) | Short-video skill in the SKILL.md format dsh reads: rebuilds a winning TikTok's formula into your own product video; copy riffkit/ into a skill root such as ~/.agents/skills | 0.1.0-rc.6 (2026-08-15) |
 
 ### Themes
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema.json",
-  "updated": "2026-08-14",
+  "updated": "2026-08-15",
   "plugins": [
     {
       "name": "dsh-base",
@@ -18223,6 +18223,21 @@
         "agents"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "riffkit",
+      "repo": "riffkit/skill",
+      "path": "riffkit",
+      "description": "Short-video skill in the SKILL.md format dsh reads: rebuilds a winning TikTok's formula into your own product video; copy riffkit/ into a skill root such as ~/.agents/skills",
+      "category": "skill",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "capabilities"
+      ]
     }
   ]
 }

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -1,6 +1,6 @@
 window.__PLUGINS__ = {
   "$schema": "./schema.json",
-  "updated": "2026-08-14",
+  "updated": "2026-08-15",
   "plugins": [
     {
       "name": "dsh-base",
@@ -18223,6 +18223,21 @@ window.__PLUGINS__ = {
         "agents"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "riffkit",
+      "repo": "riffkit/skill",
+      "path": "riffkit",
+      "description": "Short-video skill in the SKILL.md format dsh reads: rebuilds a winning TikTok's formula into your own product video; copy riffkit/ into a skill root such as ~/.agents/skills",
+      "category": "skill",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "capabilities"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema.json",
-  "updated": "2026-08-14",
+  "updated": "2026-08-15",
   "plugins": [
     {
       "name": "dsh-base",
@@ -18223,6 +18223,21 @@
         "agents"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "riffkit",
+      "repo": "riffkit/skill",
+      "path": "riffkit",
+      "description": "Short-video skill in the SKILL.md format dsh reads: rebuilds a winning TikTok's formula into your own product video; copy riffkit/ into a skill root such as ~/.agents/skills",
+      "category": "skill",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "capabilities"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds `riffkit/skill` to `data/plugins.json` as a `skill`, with `README.md` + `docs/` regenerated by `node scripts/render.mjs`. `node scripts/validate.mjs` passes (1029 plugins, 0 candidates, 26 rejected).

**Against the spam gate**

1. **Real install path** — third bullet, the `SKILL.md` layout: the repo carries `riffkit/SKILL.md` (kebab-case name, top level, no nesting), so copying `riffkit/` into a skill root is all it takes. Entry sets `path: riffkit` accordingly. Worth noting: this layout was added **today, because of this gate** — the repo previously had `SKILL.md` only at its root, which would have made the skill resolve as `skill`. Thanks for writing the bar down precisely enough to check against.
2. **Not template spam** — the skill is the published interface to a running product (riffkit.ai); `SKILL.md` is ~75 KB of hand-written protocol, not a scaffold.
3. **Loads against `verifiedAgainst: 0.1.0-rc.6`** — verified by running `@deepseek-ai/dsh-skill-filesystem@0.1.0-rc.6` (the version `@deepseek-ai/dsh@0.1.0-rc.6` depends on; note npm’s `latest` dist-tag for that package still points at the older `0.0.1-rc.3`) against a skill root containing it:

   ```
   provider ver : 0.1.0-rc.6
   riffkit      : true | name: riffkit | source: user-agents
   invocation   : {"modelInvocable":true,"userInvocable":true}
   path         : ~/.agents/skills/riffkit/SKILL.md
   body chars   : 74979
   ```

   That is discovery + frontmatter parse + full body load. I did **not** run an end-to-end generation inside dsh (that needs an API key), so if you read `verified` as requiring that, downgrade this to `unverified` — I would rather the field stay honest than be flattering.
4. **Honest description, not topic-riding** — it genuinely extends dsh: a skill dsh discovers and can invoke. It is not dsh-exclusive (the same file works in any harness reading `~/.agents/skills`), so if `skill` is meant only for dsh-specific units, say so and I will withdraw.

`official: false`, `tags: ["capabilities"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)