### PR TITLE
Triage the four candidates left over from the bot/discovery PR

### DIFF
--- a/data/candidates.json
+++ b/data/candidates.json
@@ -37,15 +37,6 @@
       "discovered": "2026-08-15"
     },
     {
-      "repo": "1cyberlangke1/tokkit",
-      "npm": "@cyberlangke/tokkit-deepseek",
-      "sources": [
-        "npm-search"
-      ],
-      "description": "DeepSeek tokenizer families for tokkit.",
-      "discovered": "2026-08-15"
-    },
-    {
       "repo": "2002yxy/dsh-nailong-desktop-pet",
       "sources": [
         "github-topic"
@@ -1257,15 +1248,6 @@
       "discovered": "2026-08-15"
     },
     {
-      "repo": "narevai/ai-billing",
-      "npm": "@ai-billing/deepseek",
-      "sources": [
-        "npm-search"
-      ],
-      "description": "DeepSeek provider for the AI Billing.",
-      "discovered": "2026-08-15"
-    },
-    {
       "repo": "nevertoday/dsh-theme-plugin",
       "sources": [
         "github-topic"
@@ -1744,15 +1726,6 @@
       ],
       "stars": 1,
       "description": "DeepSeek Harness Web UI 主题背景中心插件：主题/渐变图片背景/毛玻璃/流动氛围灯",
-      "discovered": "2026-08-15"
-    },
-    {
-      "repo": "taptap/instant-games-open-mcp",
-      "npm": "@taptap/maker",
-      "sources": [
-        "npm-search"
-      ],
-      "description": "TapTap Maker local development CLI and MCP server",
       "discovered": "2026-08-15"
     },
     {

--- a/data/rejected.json
+++ b/data/rejected.json
@@ -31,6 +31,11 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "1cyberlangke1/tokkit",
+      "reason": "general tokenizer library that ships DeepSeek vocabularies; not a dsh extension",
+      "date": "2026-08-15"
+    },
+    {
       "repo": "1lyygit/dsh-launcher",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
@@ -2676,6 +2681,11 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "narevai/ai-billing",
+      "reason": "multi-provider billing library with a DeepSeek adapter; no dsh install path",
+      "date": "2026-08-15"
+    },
+    {
       "repo": "neciszhang/dsh-desktop",
       "reason": "vendors or pins the dsh runtime rather than extending it",
       "date": "2026-08-15",
@@ -3006,6 +3016,11 @@
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "PicGo/PicGo-Core",
+      "reason": "general image-upload engine; npm-search noise",
+      "date": "2026-08-15"
     },
     {
       "repo": "pingfanfan/dsh-verify",
@@ -3561,6 +3576,11 @@
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "taptap/instant-games-open-mcp",
+      "reason": "TapTap MCP server; MCP is harness-agnostic, no dsh install path",
+      "date": "2026-08-15"
     },
     {
       "repo": "TaxolYang0000/dsh-hermes-collab-pipeline",


### PR DESCRIPTION
[#2](https://github.com/dshworks/awesome-dsh-plugins/pull/2) queued 25 candidates. The 0815 sweep absorbed 21 of them into the registry or the rejection ledger; these are the last four, all from the npm-search source, all packages that mention DeepSeek without extending dsh.

| repo | why not |
|---|---|
| `1cyberlangke1/tokkit` | tokenizer library that ships DeepSeek vocabularies |
| `narevai/ai-billing` | multi-provider billing library with a DeepSeek adapter |
| `PicGo/PicGo-Core` | general image-upload engine — 969 stars of unrelated |
| `taptap/instant-games-open-mcp` | MCP server; MCP is harness-agnostic, no dsh install path |

Recorded as **judgment** rejections, so no `recheckAfter`: none of these becomes a dsh extension by waiting. Also removed from the live candidate queue.

Worth noting the pattern — every one came from npm search rather than a topic. `fromNpm()` matches on the text `@deepseek-ai/dsh` across package metadata, which catches anything that so much as names DeepSeek in a dependency list. It is a lower-precision source than the topic sweep and its output should probably be marked as such at triage time.

`node scripts/validate.mjs` → ok (2642 plugins, 249 candidates, 761 rejected).