### PR TITLE
validate: reject descriptions that arrive already mis-encoded

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -126,10 +126,19 @@ function isRealDate(s) {
 
 // --- registry invariants ---------------------------------------------------
 
+// Some upstream GitHub descriptions arrive already destroyed: the API itself
+// returns "DSH ????:??????? + ??/????" for repos whose owner set the field from
+// a mis-encoded terminal. A registry that copies those in is passing on damage
+// its readers cannot undo.
+const MOJIBAKE = /\?{4,}|�/;
+
 function checkRegistry(registry, errors) {
   const seen = { name: new Map(), npm: new Map(), source: new Map() };
   registry.plugins.forEach((p, i) => {
     const at = `plugins[${i}] (${p.name ?? "?"})`;
+    if (p.description && MOJIBAKE.test(p.description)) {
+      errors.push(`${at}: description looks mis-encoded; write one or leave the entry out`);
+    }
     for (const [field, map] of [
       ["name", seen.name],
       ["npm", seen.npm],


### PR DESCRIPTION
GitHub's own API returns this for `seekerwxy/dsh-aurora-theme`:

```
$ gh api repos/seekerwxy/dsh-aurora-theme --jq .description
DSH ????:??????? + ??/???? + ??/??????
```

Those are literal question marks in GitHub's data — the owner set the description from a mis-encoded terminal, and the original text is gone. The automated sweeps take upstream descriptions verbatim, so without a guard that lands in the registry, where it reads as *our* corruption and no reader can undo it.

Nothing in the registry trips this today (**0 of 2,642**). This is a guard for what the watch will pull in tomorrow.

Ported from the same check in [awesome-dsh-themes#31](https://github.com/dshworks/awesome-dsh-themes/pull/31), where the very first discovery run queued a candidate with exactly this shape.

Verified it fires — temporarily corrupting one entry:

```
validate: 1 error(s)
  - plugins[2641] (dsh-skill-cocosgt): description looks mis-encoded; write one or leave the entry out
```

`node scripts/validate.mjs` → ok (2642 plugins, 249 candidates, 761 rejected).