### PR TITLE
Add 20 plugins that only code search can see, including 6 dynamic ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2642 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2662 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -74,7 +74,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2535 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
+2555 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dshworks.github.io/awesome-dsh-plugins/) always hold everything.
 
@@ -110,7 +110,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-client-ui-mobile-adapt | 8 | [Hotsteel2901/dsh-client-ui-mobile-adapt](https://github.com/Hotsteel2901/dsh-client-ui-mobile-adapt) | Mobile adaptation for the DeepSeek Harness Web GUI: single-column layout, sidebar drawer, compact header/composer, fullscreen settings, trajectory floating details, stats pill panel | 0.1.0-rc.6 (2026-08-14) |
 | dsh-fail-logger | 8 | [Areium/dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) · [npm](https://www.npmjs.com/package/dsh-fail-logger) | DSH 插件：全模式工具失败自动实录——把原生工具、PTC(Code Mode) run_code、代码内嵌工具调用的失败按错因去重计数，自动写入 skill 的机器维护区段，越用越少错。Auto-record tool failures from every execution mode into a skill's machine-maintained section (dedup + cou | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 267. **[all 267 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 269. **[all 269 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Terminals & desktop
 
@@ -124,6 +124,7 @@ TUIs, desktop shells, headless runners.
 | dsh-desktop | 210 | [dataelement/dsh-desktop](https://github.com/dataelement/dsh-desktop) | A cross-platform desktop shell for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tianshu-tui | 143 | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) · [npm](https://www.npmjs.com/package/@huiliyi37/dsh-tianshu-tui) | Terminal UI for dsh shipped as an installable profile bundle | 0.1.0-rc.5 (2026-08-13) |
 | deepseek-harness-desktop-ningbain | 39 | [ningbainb/deepseek-harness-desktop](https://github.com/ningbainb/deepseek-harness-desktop/tree/HEAD/apps/dsh-desktop) | Lossless desktop shell for DeepSeek Harness and the complete dsh-web-ui plugin collection | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-app | 27 | [RongleCat/deepseek-app](https://github.com/RongleCat/deepseek-app) | Desktop workbench for DeepSeek Harness — Grok App visual shell, DSH engine | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-tui-openmaai | 25 | [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui/tree/HEAD/npm) | Terminal-native agent UI for DeepSeek Harness; standalone CLI or dsh profile bundle | 0.1.0-rc.6 (2026-08-15) |
 | DSHDesktop | 21 | [CCMu04/DSHDesktop](https://github.com/CCMu04/DSHDesktop) | Unofficial Windows desktop shell for the unmodified DeepSeek Harness Web UI | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-cc1252 | 17 | [cc1252/deepseek-harness-desktop](https://github.com/cc1252/deepseek-harness-desktop/tree/HEAD/harness) | Unpruned runtime payload for the Electron wrapper | 0.1.0-rc.6 (2026-08-15) |
@@ -140,11 +141,10 @@ TUIs, desktop shells, headless runners.
 | dsh-desktop-ethanwea | 5 | [ethanweave/dsh-desktop](https://github.com/ethanweave/dsh-desktop/tree/HEAD/runtime) | DeepSeek Harness 桌面应用（类 Codex）：原生窗口 + 系统托盘 | 0.1.0-rc.6 (2026-08-15) |
 | DSH-Plugs | 5 | [JustGenius-s/DSH-Plugs](https://github.com/JustGenius-s/DSH-Plugs/tree/HEAD/plugins/dsh-desktop-update) | Desktop update badge for DSH-Desktop: renders an update icon next to the sidebar Settings button, driven by window.dshDesktop (Electron preload bridge) | 0.1.0-rc.6 (2026-08-15) |
 | Deepseek-Harness-as-Desktop | 4 | [KhanZou/Deepseek-Harness-as-Desktop](https://github.com/KhanZou/Deepseek-Harness-as-Desktop/tree/HEAD/dsh-desktop-framework) | Unified desktop framework for the DSH Web UI: generic settings tabs/items (window.__DSH_SETTINGS__), right/bottom panel shells (window.__DSH_PANELS__), and the Files/Changes/Terminal tabs with | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-harness-desktop-bailang1 | 4 | [bailang1218/deepseek-harness-desktop](https://github.com/bailang1218/deepseek-harness-desktop) | Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-tui | 4 | [Hilbert-beinghappy/deepseek-tui](https://github.com/Hilbert-beinghappy/deepseek-tui) | A pluggable DeepSeek-colored terminal surface for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
-| dib | 4 | [MaimoryLab/dib](https://github.com/MaimoryLab/dib/tree/HEAD/plugins/dsh-desktop) | DeepSeek Harness desktop UI extensions | 0.1.0-rc.6 (2026-08-15) |
-| DSH-closerAI | 4 | [sb1733831438-maker/DSH-closerAI](https://github.com/sb1733831438-maker/DSH-closerAI/tree/HEAD/apps/desktop) | CloserAI Electron desktop shell: hardened window that hosts the DeepSeek Harness web UI. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 111. **[all 111 →](lists/terminals-desktop.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 116. **[all 116 →](lists/terminals-desktop.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Tools & capabilities
 
@@ -212,7 +212,7 @@ Image understanding for text-only models.
 | dsh-codex-tools | 3 | [SPYQWER1/dsh-codex-tools](https://github.com/SPYQWER1/dsh-codex-tools) · [npm](https://www.npmjs.com/package/dsh-codex-tools) | Codex-backed web search, image generation, and image understanding tools for the DeepSeek Harness. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-docker-devlythe | 3 | [devLythen/dsh-docker](https://github.com/devLythen/dsh-docker) | Docker image for DeepSeek Harness, with self-hosted deployment supported | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 140. **[all 140 →](lists/vision.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 141. **[all 141 →](lists/vision.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Agents & orchestration
 
@@ -246,7 +246,7 @@ Subagents, workflows, cross-session coordination.
 | dsh-continual-evolve | 5 | [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) · [npm](https://www.npmjs.com/package/dsh-continual-evolve) | Continual self-evolution for DeepSeek Harness: versioned, auditable, rollback-safe harness state refined from session trajectories. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-inspect | 5 | [omdsh-dev/dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) | 发现问题 → 修复交付 → 质量复查 的简单闭环插件：checkup（对抗式检查+红队验证）/ fix（根因→修复→验证）/ review（对抗式复查）三个工具，基于官方 workflow 引擎。 | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 214. **[all 214 →](lists/agents-orchestration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 217. **[all 217 →](lists/agents-orchestration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Memory & sessions
 
@@ -280,7 +280,7 @@ Memory systems, context management, session search/rewind/export.
 | dsh-btw | 4 | [iyllyt/dsh-btw](https://github.com/iyllyt/dsh-btw) · [npm](https://www.npmjs.com/package/dsh-btw) | Transient /btw side questions for DeepSeek Harness: immediate while the main agent is busy, context-sharing, tool-free, one-shot, cache-aware, and invisible to the main session catalog. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-companion-williamj | 4 | [william-jin-cmu/dsh-companion](https://github.com/william-jin-cmu/dsh-companion/tree/HEAD/dsh-bridge) | DSH Companion 的本地网关插件：把宿主 ApiProxy 暴露为 127.0.0.1 上的 HTTP + SSE（token 鉴权），供桌面壳驱动会话 | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 273. **[all 273 →](lists/memory-sessions.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 275. **[all 275 →](lists/memory-sessions.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Models & providers
 
@@ -348,7 +348,7 @@ Bridges to and from Claude Code, Codex, and other harnesses.
 | dsh-vscode | 4 | [MJ-Chang/dsh-vscode](https://github.com/MJ-Chang/dsh-vscode) | Run DeepSeek Harness inside VS Code: chat with the agent and edit your project, like Claude Code / Codex / Copilot. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-beacons | 3 | [Da-Mie/dsh-beacons](https://github.com/Da-Mie/dsh-beacons) · [npm](https://www.npmjs.com/package/dsh-beacons) | Codex/OpenChamber-style prompt-navigator rail with scroll-spy — a DeepSeek Harness plugin | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 92. **[all 92 →](lists/interop-migration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 93. **[all 93 →](lists/interop-migration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Channels & remote
 
@@ -382,7 +382,7 @@ IM bridges and remote control: Feishu, Telegram, WeCom, DingTalk.
 | dsh-plugin-wechat | 3 | [gnulife/dsh-plugin-wechat](https://github.com/gnulife/dsh-plugin-wechat) | DeepSeek Harness (DSH) 个人微信 ClawBot 插件：OpenClaw 负责微信通道（扫码登录/收发消息），DSH 负责大脑，两者通过 OpenAI 兼容协议桥接。 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-wecom | 3 | [TtTRz/dsh-wecom](https://github.com/TtTRz/dsh-wecom) | dsh-wecom: a WeCom AI Bot channel for DeepSeek Harness — each chat runs a persistent, preset-backed agent over the official long connection. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 77. **[all 77 →](lists/channels-remote.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 78. **[all 78 →](lists/channels-remote.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Notifications
 
@@ -416,7 +416,7 @@ Alerting the human: desktop, sound, even a phone call.
 | dsh-notify-bark | 1 | [pc439527/dsh-notify-bark](https://github.com/pc439527/dsh-notify-bark) | Bark 推送通知插件：DSH Host 端监听回合结束 / 等待回答 / 等待授权等事件，通过 Bark Server 推送到 iPhone。设置页经专用 RPC 读写 Host 配置（Bark 地址脱敏，不落地到浏览器）。 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-notify-plugin | 1 | [orange1926/dsh-notify-plugin](https://github.com/orange1926/dsh-notify-plugin) · [npm](https://www.npmjs.com/package/@dsh-local/notify) | DSH 回答完成提醒插件：turn/end 时提示音 + Windows 系统通知，点击通知可聚焦并切换会话，设置里可自由开关。 | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 39. **[all 39 →](lists/notifications.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 40. **[all 40 →](lists/notifications.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Usage & cost
 
@@ -450,7 +450,7 @@ Token accounting, billing, balance, quota.
 | dsh-usage-chart | 5 | [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) · [npm](https://www.npmjs.com/package/dsh-usage-chart) | Real-time token usage, cost estimates, per-round charts, and DeepSeek API balance for the Web GUI. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-usage-stats ⭐ | 5 | [lanlandeli/dsh-usage-stats](https://github.com/lanlandeli/dsh-usage-stats) | Beautiful token analytics for DeepSeek Harness — trends, activity heatmaps, model breakdowns, and data exports. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 198. **[all 198 →](lists/usage-cost.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 200. **[all 200 →](lists/usage-cost.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Observability & evidence
 
@@ -552,7 +552,7 @@ In-UI stores, installers, skill managers.
 | dsh-hub | 4 | [omdsh-dev/dsh-hub](https://github.com/omdsh-dev/dsh-hub) | OMDSH community extension hub built on official DeepSeek Harness contracts | 0.1.0-rc.6 (2026-08-14) |
 | dsh-mcp-admin | 4 | [kairoz9/dsh-mcp-admin](https://github.com/kairoz9/dsh-mcp-admin) · [npm](https://www.npmjs.com/package/dsh-mcp-admin) | MCP admin for dsh: /mcp server status and per-profile MCP server management (add/edit/delete/enable) from the settings page, via a typert remote. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 122. **[all 122 →](lists/plugin-managers-stores.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 123. **[all 123 →](lists/plugin-managers-stores.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Developer tools
 
@@ -620,7 +620,7 @@ Research workbenches, RAG, learning modes.
 | dsh-plugin-knowledge-graph | 3 | [Luke-Yong/dsh-plugin-knowledge-graph](https://github.com/Luke-Yong/dsh-plugin-knowledge-graph) | DeepSeek Harness plugin: a read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL). | 0.1.0-rc.6 (2026-08-15) |
 | dsh-research-notes | 3 | [fff122/dsh-research-notes](https://github.com/fff122/dsh-research-notes) | A local research notes plugin for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 86. **[all 86 →](lists/knowledge-research.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 87. **[all 87 →](lists/knowledge-research.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Fun
 

--- a/data/candidates.json
+++ b/data/candidates.json
@@ -1091,15 +1091,6 @@
       "discovered": "2026-08-15"
     },
     {
-      "repo": "linkage18/donecheck",
-      "sources": [
-        "github-topic"
-      ],
-      "stars": 1,
-      "description": "A plugin for DSH that checks whether your work has actually been completed. It automatically loops over the model’s responses to check for errors or shortcomings.",
-      "discovered": "2026-08-15"
-    },
-    {
       "repo": "liyupi/dsh-kun-like-pet",
       "sources": [
         "github-topic"

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -46847,6 +46847,358 @@
         "capabilities"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-app",
+      "repo": "RongleCat/deepseek-app",
+      "description": "Desktop workbench for DeepSeek Harness — Grok App visual shell, DSH engine",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 27,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-bailang1",
+      "repo": "bailang1218/deepseek-harness-desktop",
+      "description": "Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 4,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "SKILLS-featherh",
+      "repo": "FeatherHunter/SKILLS",
+      "path": "dsh-plugin/dsh-feishu-link/package",
+      "description": "DSH 插件 — Agent 接入飞书/Lark IM（动态 + npm 安装 双形态）。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 3,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "channels",
+        "agents"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-evanmorm",
+      "repo": "evanmormmm/deepseek-harness-desktop",
+      "description": "Community Windows desktop distribution of DeepSeek Harness with a verified installer and portable runtime.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "marketplace",
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dsh-cxsm",
+      "repo": "negativegluon/dsh-cxsm",
+      "description": "Codex-style conversation summary tab for DeepSeek Harness (DSH).",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "interop"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-harness-desktop-0reki",
+      "repo": "0reki/deepseek-harness-desktop",
+      "description": "Native desktop client for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "deepseek-plugins",
+      "repo": "bitterSmilezzz/deepseek-plugins",
+      "path": "dsh-agent-teams",
+      "description": "AgentTeams for DeepSeek Harness: multi-agent team collaboration (captain, members, tasks with dependencies, messaging) driven by natural language, with a tree monitor in the web GUI",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "observability"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "DeepSeek-Harness-Electron-",
+      "repo": "FlyPig-tt/DeepSeek-Harness-Electron-",
+      "description": "DeepSeek Harness 的 Electron 桌面版",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-desktop-xenia092",
+      "repo": "Xenia0922/dsh-desktop",
+      "description": "DeepSeek Harness desktop application",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-locale-ja",
+      "repo": "fang2hou/dsh-locale-ja",
+      "description": "Japanese (日本語) interface for DeepSeek Harness — a standard DSH client plugin that adds 日本語 as a selectable UI language alongside 中文 and English, with Japanese system fonts.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dshicon",
+      "repo": "fezeryang/dshicon",
+      "description": "Ambient status-driven WebGL2 ORB avatar for DeepSeek Harness: a host task-status state machine plus a client orb that reflects agent/tool/error phase and teleports into the running turn's status row.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "omp2dsh-plugins",
+      "repo": "Fun10165/omp2dsh-plugins",
+      "path": "packages/bang",
+      "description": "! prefix quick command runner: !cmd injects its result into the session flow (context), !!cmd shows it in a dock panel marked excluded-from-context. Ported from omp's bang/bash input modes.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-notification-sounds",
+      "repo": "Heldea-xianmiao/dsh-plugin-notification-sounds",
+      "description": "DSH 提示音插件（原生常驻版）：为开始运行、成功完成、异常中断、需要审批、子代理完成等事件分别设置提示音，支持逐事件上传本地音频文件。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "notifications",
+        "safety"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-timeline-hemo9493",
+      "repo": "hemo94931/dsh-timeline",
+      "description": "会话时间轴：在 dsh WebUI 会话消息列右缘渲染用户消息刻度导航条（悬浮摘要 / 点击跳转 / ▲▼ 导航 / 连续位置指示）",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "opencode-go-usage-badge",
+      "repo": "UniverseCA/opencode-go-usage-badge",
+      "description": "OpenCode Go subscription usage as a badge in the conversation header, with a click-to-open rolling/weekly/monthly detail card.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
+    },
+    {
+      "name": "dsh-plugin-bgpic",
+      "repo": "luyyooo/dsh-plugin-bgpic",
+      "description": "Background image control in the top-right: local or URL images, custom cropping, opacity and surface translucency, ordered or random slideshow.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui",
+        "fun"
+      ]
+    },
+    {
+      "name": "dsh-plugin-kaoyan",
+      "repo": "luyyooo/dsh-plugin-kaoyan",
+      "description": "Postgraduate-exam study workbench in the sidebar: task board, mistake book with AI classification, reading drills, vocabulary, essay marking, and a politics monthly digest.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "knowledge",
+        "ui"
+      ]
+    },
+    {
+      "name": "donecheck",
+      "repo": "linkage18/donecheck",
+      "description": "Automatic review-and-repair loop after every answer: a reviewer sees the full reply plus the actual tool results and iterates with tool access until the work is really done.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "safety"
+      ]
+    },
+    {
+      "name": "dsh-multimedia-viewer",
+      "repo": "chaiyujin/dsh-multimedia-viewer",
+      "description": "Browse images and video from the current workspace inside the harness page: floating button, filtered thumbnail grid, lightbox and inline playback. Scoped to the session cwd.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "vision",
+        "capabilities"
+      ]
+    },
+    {
+      "name": "dsh-usage-meter-hohband",
+      "repo": "hohband/DSH-Plugins",
+      "path": "usage-meter",
+      "description": "Sidebar balance and usage readout for two providers at once: DeepSeek official and OpenCode Go.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 }

--- a/data/rejected.json
+++ b/data/rejected.json
@@ -25,6 +25,18 @@
       "date": "2026-08-13"
     },
     {
+      "repo": "112GT/deepseek-harness-vscode",
+      "reason": "vendored clone of the harness (harness/apps/cli)",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-11-13"
+    },
+    {
+      "repo": "1501545083/DSH-llmCodegraph",
+      "reason": "no dsh install path at any depth",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-09-05"
+    },
+    {
       "repo": "15828148/dsh-portable-launcher",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
@@ -1494,6 +1506,12 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "Hcj171388/dshc",
+      "reason": "vendored clone of the harness (deepseek-ai-deepseek-harness-*/apps/cli)",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-11-13"
+    },
+    {
       "repo": "helays/dsh-tray",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
@@ -2781,6 +2799,11 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "OBdangshang07/DSH_Creative_Workshop",
+      "reason": "plugin discovery site, not an installable dsh extension",
+      "date": "2026-08-15"
+    },
+    {
       "repo": "obrige/dsh-docker",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
@@ -2915,6 +2938,12 @@
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "oykb58246/dsh-desktop",
+      "reason": "vendored clone of the harness (deepseek-harness/apps/cli)",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-11-13"
     },
     {
       "repo": "paean-ai/8x-skills",
@@ -3068,6 +3097,12 @@
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "programmingWTF/NUAAgent",
+      "reason": "vendors first-party dsh packages; no extension of its own",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-11-13"
     },
     {
       "repo": "PRTSPro/novel-workbench",
@@ -3362,6 +3397,12 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "shiro123444/Cognitive-AI",
+      "reason": "no dsh install path at any depth",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-09-05"
+    },
+    {
       "repo": "ShuaixinHuang/deepseek-harness-desktop",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
@@ -3486,6 +3527,12 @@
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "stars2022/Dsh-macUI",
+      "reason": "third-party native macOS/iOS client, not an extension",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-11-13"
     },
     {
       "repo": "Stxr/deepseek-harness-desktop",
@@ -3870,6 +3917,11 @@
       "recheckAfter": "2026-09-05"
     },
     {
+      "repo": "wdnmdtonyma/SOTA-Agent-LLM-Wiki",
+      "reason": "wiki, not an installable dsh extension",
+      "date": "2026-08-15"
+    },
+    {
       "repo": "web-casa/dsh-gui",
       "reason": "vendors or pins the dsh runtime rather than extending it",
       "date": "2026-08-15",
@@ -3878,6 +3930,12 @@
     {
       "repo": "weekitmo/vision-mcp",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "WEIFENG2333/phistory",
+      "reason": "harness-agnostic system-prompt archiver; no dsh install path found",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
     },
@@ -4326,6 +4384,12 @@
     {
       "repo": "Yoahoug/dsh-launcher",
       "reason": "no dsh install path at any depth: no dsh manifest, no @deepseek-ai dependency, no SKILL.md",
+      "date": "2026-08-15",
+      "recheckAfter": "2026-09-05"
+    },
+    {
+      "repo": "YSheldon/0dayWatchDog",
+      "reason": "0-day crawler/collector; no dsh install path",
       "date": "2026-08-15",
       "recheckAfter": "2026-09-05"
     },

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -46847,6 +46847,358 @@ window.__PLUGINS__ = {
         "capabilities"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-app",
+      "repo": "RongleCat/deepseek-app",
+      "description": "Desktop workbench for DeepSeek Harness — Grok App visual shell, DSH engine",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 27,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-bailang1",
+      "repo": "bailang1218/deepseek-harness-desktop",
+      "description": "Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 4,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "SKILLS-featherh",
+      "repo": "FeatherHunter/SKILLS",
+      "path": "dsh-plugin/dsh-feishu-link/package",
+      "description": "DSH 插件 — Agent 接入飞书/Lark IM（动态 + npm 安装 双形态）。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 3,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "channels",
+        "agents"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-evanmorm",
+      "repo": "evanmormmm/deepseek-harness-desktop",
+      "description": "Community Windows desktop distribution of DeepSeek Harness with a verified installer and portable runtime.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "marketplace",
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dsh-cxsm",
+      "repo": "negativegluon/dsh-cxsm",
+      "description": "Codex-style conversation summary tab for DeepSeek Harness (DSH).",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "interop"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-harness-desktop-0reki",
+      "repo": "0reki/deepseek-harness-desktop",
+      "description": "Native desktop client for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "deepseek-plugins",
+      "repo": "bitterSmilezzz/deepseek-plugins",
+      "path": "dsh-agent-teams",
+      "description": "AgentTeams for DeepSeek Harness: multi-agent team collaboration (captain, members, tasks with dependencies, messaging) driven by natural language, with a tree monitor in the web GUI",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "observability"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "DeepSeek-Harness-Electron-",
+      "repo": "FlyPig-tt/DeepSeek-Harness-Electron-",
+      "description": "DeepSeek Harness 的 Electron 桌面版",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-desktop-xenia092",
+      "repo": "Xenia0922/dsh-desktop",
+      "description": "DeepSeek Harness desktop application",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-locale-ja",
+      "repo": "fang2hou/dsh-locale-ja",
+      "description": "Japanese (日本語) interface for DeepSeek Harness — a standard DSH client plugin that adds 日本語 as a selectable UI language alongside 中文 and English, with Japanese system fonts.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dshicon",
+      "repo": "fezeryang/dshicon",
+      "description": "Ambient status-driven WebGL2 ORB avatar for DeepSeek Harness: a host task-status state machine plus a client orb that reflects agent/tool/error phase and teleports into the running turn's status row.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "omp2dsh-plugins",
+      "repo": "Fun10165/omp2dsh-plugins",
+      "path": "packages/bang",
+      "description": "! prefix quick command runner: !cmd injects its result into the session flow (context), !!cmd shows it in a dock panel marked excluded-from-context. Ported from omp's bang/bash input modes.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-notification-sounds",
+      "repo": "Heldea-xianmiao/dsh-plugin-notification-sounds",
+      "description": "DSH 提示音插件（原生常驻版）：为开始运行、成功完成、异常中断、需要审批、子代理完成等事件分别设置提示音，支持逐事件上传本地音频文件。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "notifications",
+        "safety"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-timeline-hemo9493",
+      "repo": "hemo94931/dsh-timeline",
+      "description": "会话时间轴：在 dsh WebUI 会话消息列右缘渲染用户消息刻度导航条（悬浮摘要 / 点击跳转 / ▲▼ 导航 / 连续位置指示）",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "opencode-go-usage-badge",
+      "repo": "UniverseCA/opencode-go-usage-badge",
+      "description": "OpenCode Go subscription usage as a badge in the conversation header, with a click-to-open rolling/weekly/monthly detail card.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
+    },
+    {
+      "name": "dsh-plugin-bgpic",
+      "repo": "luyyooo/dsh-plugin-bgpic",
+      "description": "Background image control in the top-right: local or URL images, custom cropping, opacity and surface translucency, ordered or random slideshow.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui",
+        "fun"
+      ]
+    },
+    {
+      "name": "dsh-plugin-kaoyan",
+      "repo": "luyyooo/dsh-plugin-kaoyan",
+      "description": "Postgraduate-exam study workbench in the sidebar: task board, mistake book with AI classification, reading drills, vocabulary, essay marking, and a politics monthly digest.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "knowledge",
+        "ui"
+      ]
+    },
+    {
+      "name": "donecheck",
+      "repo": "linkage18/donecheck",
+      "description": "Automatic review-and-repair loop after every answer: a reviewer sees the full reply plus the actual tool results and iterates with tool access until the work is really done.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "safety"
+      ]
+    },
+    {
+      "name": "dsh-multimedia-viewer",
+      "repo": "chaiyujin/dsh-multimedia-viewer",
+      "description": "Browse images and video from the current workspace inside the harness page: floating button, filtered thumbnail grid, lightbox and inline playback. Scoped to the session cwd.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "vision",
+        "capabilities"
+      ]
+    },
+    {
+      "name": "dsh-usage-meter-hohband",
+      "repo": "hohband/DSH-Plugins",
+      "path": "usage-meter",
+      "description": "Sidebar balance and usage readout for two providers at once: DeepSeek official and OpenCode Go.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -46847,6 +46847,358 @@
         "capabilities"
       ],
       "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-app",
+      "repo": "RongleCat/deepseek-app",
+      "description": "Desktop workbench for DeepSeek Harness — Grok App visual shell, DSH engine",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 27,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-bailang1",
+      "repo": "bailang1218/deepseek-harness-desktop",
+      "description": "Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 4,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "SKILLS-featherh",
+      "repo": "FeatherHunter/SKILLS",
+      "path": "dsh-plugin/dsh-feishu-link/package",
+      "description": "DSH 插件 — Agent 接入飞书/Lark IM（动态 + npm 安装 双形态）。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 3,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "channels",
+        "agents"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "deepseek-harness-desktop-evanmorm",
+      "repo": "evanmormmm/deepseek-harness-desktop",
+      "description": "Community Windows desktop distribution of DeepSeek Harness with a verified installer and portable runtime.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "marketplace",
+        "terminal"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dsh-cxsm",
+      "repo": "negativegluon/dsh-cxsm",
+      "description": "Codex-style conversation summary tab for DeepSeek Harness (DSH).",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 2,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "interop"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "deepseek-harness-desktop-0reki",
+      "repo": "0reki/deepseek-harness-desktop",
+      "description": "Native desktop client for DeepSeek Harness",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "deepseek-plugins",
+      "repo": "bitterSmilezzz/deepseek-plugins",
+      "path": "dsh-agent-teams",
+      "description": "AgentTeams for DeepSeek Harness: multi-agent team collaboration (captain, members, tasks with dependencies, messaging) driven by natural language, with a tree monitor in the web GUI",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "observability"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "DeepSeek-Harness-Electron-",
+      "repo": "FlyPig-tt/DeepSeek-Harness-Electron-",
+      "description": "DeepSeek Harness 的 Electron 桌面版",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-desktop-xenia092",
+      "repo": "Xenia0922/dsh-desktop",
+      "description": "DeepSeek Harness desktop application",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "terminal"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-locale-ja",
+      "repo": "fang2hou/dsh-locale-ja",
+      "description": "Japanese (日本語) interface for DeepSeek Harness — a standard DSH client plugin that adds 日本語 as a selectable UI language alongside 中文 and English, with Japanese system fonts.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "dshicon",
+      "repo": "fezeryang/dshicon",
+      "description": "Ambient status-driven WebGL2 ORB avatar for DeepSeek Harness: a host task-status state machine plus a client orb that reflects agent/tool/error phase and teleports into the running turn's status row.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "capabilities"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "omp2dsh-plugins",
+      "repo": "Fun10165/omp2dsh-plugins",
+      "path": "packages/bang",
+      "description": "! prefix quick command runner: !cmd injects its result into the session flow (context), !!cmd shows it in a dock panel marked excluded-from-context. Ported from omp's bang/bash input modes.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-notification-sounds",
+      "repo": "Heldea-xianmiao/dsh-plugin-notification-sounds",
+      "description": "DSH 提示音插件（原生常驻版）：为开始运行、成功完成、异常中断、需要审批、子代理完成等事件分别设置提示音，支持逐事件上传本地音频文件。",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "notifications",
+        "safety"
+      ],
+      "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-timeline-hemo9493",
+      "repo": "hemo94931/dsh-timeline",
+      "description": "会话时间轴：在 dsh WebUI 会话消息列右缘渲染用户消息刻度导航条（悬浮摘要 / 点击跳转 / ▲▼ 导航 / 连续位置指示）",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "memory",
+        "ui"
+      ],
+      "pushedAt": "2026-08-14"
+    },
+    {
+      "name": "opencode-go-usage-badge",
+      "repo": "UniverseCA/opencode-go-usage-badge",
+      "description": "OpenCode Go subscription usage as a badge in the conversation header, with a click-to-open rolling/weekly/monthly detail card.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
+    },
+    {
+      "name": "dsh-plugin-bgpic",
+      "repo": "luyyooo/dsh-plugin-bgpic",
+      "description": "Background image control in the top-right: local or URL images, custom cropping, opacity and surface translucency, ordered or random slideshow.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui",
+        "fun"
+      ]
+    },
+    {
+      "name": "dsh-plugin-kaoyan",
+      "repo": "luyyooo/dsh-plugin-kaoyan",
+      "description": "Postgraduate-exam study workbench in the sidebar: task board, mistake book with AI classification, reading drills, vocabulary, essay marking, and a politics monthly digest.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "knowledge",
+        "ui"
+      ]
+    },
+    {
+      "name": "donecheck",
+      "repo": "linkage18/donecheck",
+      "description": "Automatic review-and-repair loop after every answer: a reviewer sees the full reply plus the actual tool results and iterates with tool access until the work is really done.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 1,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "agents",
+        "safety"
+      ]
+    },
+    {
+      "name": "dsh-multimedia-viewer",
+      "repo": "chaiyujin/dsh-multimedia-viewer",
+      "description": "Browse images and video from the current workspace inside the harness page: floating button, filtered thumbnail grid, lightbox and inline playback. Scoped to the session cwd.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "vision",
+        "capabilities"
+      ]
+    },
+    {
+      "name": "dsh-usage-meter-hohband",
+      "repo": "hohband/DSH-Plugins",
+      "path": "usage-meter",
+      "description": "Sidebar balance and usage readout for two providers at once: DeepSeek official and OpenCode Go.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 }

--- a/lists/agents-orchestration.md
+++ b/lists/agents-orchestration.md
@@ -4,7 +4,7 @@
 
 Subagents, workflows, cross-session coordination.
 
-214 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+217 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -121,6 +121,8 @@ Subagents, workflows, cross-session coordination.
 | agent-plaza | 1 | [agent-plaza/agent-plaza](https://github.com/agent-plaza/agent-plaza) | Zero-signup public plaza for AI agents — speak, read, discover | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-flow | 1 | [alison-xx/deepseek-harness-flow](https://github.com/alison-xx/deepseek-harness-flow) | Community visual workflow and multi-model evaluation plugin for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-toolkit | 1 | [huangmouren2023/deepseek-harness-toolkit](https://github.com/huangmouren2023/deepseek-harness-toolkit/tree/HEAD/tools/dsh-nudge) | Nudge the model when a task errors or is interrupted: on terminal request failure, follow up so the agent explains the error or resumes from the interruption instead of going silent. | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-plugins | 1 | [bitterSmilezzz/deepseek-plugins](https://github.com/bitterSmilezzz/deepseek-plugins/tree/HEAD/dsh-agent-teams) | AgentTeams for DeepSeek Harness: multi-agent team collaboration (captain, members, tasks with dependencies, messaging) driven by natural language, with a tree monitor in the web GUI | 0.1.0-rc.6 (2026-08-15) |
+| donecheck | 1 | [linkage18/donecheck](https://github.com/linkage18/donecheck) | Automatic review-and-repair loop after every answer: a reviewer sees the full reply plus the actual tool results and iterates with tool access until the work is really done. | unverified |
 | dsh-acp | 1 | [cnctem/dsh-acp](https://github.com/cnctem/dsh-acp) | Agent Client Protocol (ACP) JSON-RPC stdio server for DeepSeek Harness — bridges Zed and other IDEs to dsh agents | 0.1.0-rc.6 (2026-08-15) |
 | dsh-advisor-glangzh | 1 | [glangzh/dsh-advisor](https://github.com/glangzh/dsh-advisor) · [npm](https://www.npmjs.com/package/dsh-advisor-plugin) | Advisor strategy for DeepSeek Harness: escalate hard decisions from the executor (deepseek-v4-flash) to deepseek-v4-pro through the official subagents channel. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-agent-life | 1 | [jonah791/dsh-agent-life](https://github.com/jonah791/dsh-agent-life) | 数字生命循环原语：可打断的 sleep（到期自我唤醒）+ 醒来状态注入 + 事故文件读取 + 决策日志。零规则——睡多久/醒来做什么由 agent 自主决定。 | 0.1.0-rc.6 (2026-08-15) |
@@ -216,6 +218,7 @@ Subagents, workflows, cross-session coordination.
 | dsh-visual-plan | 0 | [JIAQI23333/dsh-visual-plan](https://github.com/JIAQI23333/dsh-visual-plan) | Visual plan mode for DeepSeek Harness: structured plan.json + plan.md, an editable React Flow canvas, comments, plan diff, versioned revisions, and reliable write-back to the agent. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-voice-jessenjx | 0 | [Jesse-njx/dsh-voice](https://github.com/Jesse-njx/dsh-voice) | dsh-voice — voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), and leave walk-away narration on long headless runs. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-workflow-worktree | 0 | [lisycotana/dsh-workflow-worktree](https://github.com/lisycotana/dsh-workflow-worktree) | Git worktree isolation backend for DeepSeek Harness workflows: binds each write-capable workflow agent to its own recoverable checkout. | 0.1.0-rc.6 (2026-08-15) |
+| dshicon | 0 | [fezeryang/dshicon](https://github.com/fezeryang/dshicon) | Ambient status-driven WebGL2 ORB avatar for DeepSeek Harness: a host task-status state machine plus a client orb that reflects agent/tool/error phase and teleports into the running turn's status row. | 0.1.0-rc.6 (2026-08-15) |
 | math-research-dsh | 0 | [xsoc1/math-research-dsh](https://github.com/xsoc1/math-research-dsh) | Rigorous open mathematics research suite for DeepSeek Harness: four agent skills (rigorous-open-math-research, manage-math-research-program, math-research-workflow, lean-verify) with CI-verified | 0.1.0-rc.6 (2026-08-15) |
 | pptkit-presentation | 0 | [openHacking/pptkit-presentation](https://github.com/openHacking/pptkit-presentation/tree/HEAD/packages/dsh-plugin-pptkit-presentation) | DeepSeek Harness plugin bundle that registers the pptkit-presentation Agent Skill (PPTKit deck authoring, preview, and PPTX export) with DSH's skill catalog. | 0.1.0-rc.6 (2026-08-15) |
 | prompt-polish | 0 | [JOJO666888888/prompt-polish](https://github.com/JOJO666888888/prompt-polish) | dsh 提示词优化助手：发送前调用专门的提示词工程 agent 润色/补全/扩写命令，支持重写、多轮改写与撤回（动态 client 插件，随 harness 启动自动加载）。 | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/channels-remote.md
+++ b/lists/channels-remote.md
@@ -4,7 +4,7 @@
 
 IM bridges and remote control: Feishu, Telegram, WeCom, DingTalk.
 
-77 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+78 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -34,6 +34,7 @@ IM bridges and remote control: Feishu, Telegram, WeCom, DingTalk.
 | dsh-plugin-wechat | 3 | [gnulife/dsh-plugin-wechat](https://github.com/gnulife/dsh-plugin-wechat) | DeepSeek Harness (DSH) 个人微信 ClawBot 插件：OpenClaw 负责微信通道（扫码登录/收发消息），DSH 负责大脑，两者通过 OpenAI 兼容协议桥接。 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-wecom | 3 | [TtTRz/dsh-wecom](https://github.com/TtTRz/dsh-wecom) | dsh-wecom: a WeCom AI Bot channel for DeepSeek Harness — each chat runs a persistent, preset-backed agent over the official long connection. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-weixin-skylar | 3 | [skylar-fei/dsh-wechat-maid](https://github.com/skylar-fei/dsh-wechat-maid/tree/HEAD/packages/dsh-weixin) | DSH Web 插件合集：微信机器人（连接 + 主动消息/定时推送）+ 深蓝女仆桌宠，两个插件共享构建预设的单仓库。 | 0.1.0-rc.6 (2026-08-14) |
+| SKILLS-featherh | 3 | [FeatherHunter/SKILLS](https://github.com/FeatherHunter/SKILLS/tree/HEAD/dsh-plugin/dsh-feishu-link/package) | DSH 插件 — Agent 接入飞书/Lark IM（动态 + npm 安装 双形态）。 | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-remote | 2 | [liguobao/deepseek-harness-remote](https://github.com/liguobao/deepseek-harness-remote) · [npm](https://www.npmjs.com/package/deepseek-harness-remote) | Secure remote control for DeepSeek Harness: paired clients view sessions, continue chats, and handle approvals while the harness stays on the host. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-cc-connect | 2 | [whiteguo233/dsh-cc-connect](https://github.com/whiteguo233/dsh-cc-connect) | Bridge a running cc-connect instance into DeepSeek Harness: push messages to Feishu/WeChat/Telegram sessions and discover projects via cc_connect_send / cc_connect_list tools. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-cowork | 2 | [Jesse-njx/dsh-cowork](https://github.com/Jesse-njx/dsh-cowork/tree/HEAD/packages/chatnode-wechat) | Chat with, monitor, and approve your DSH agents from WeChat — an iLink gateway + conversation node bundle for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/interop-migration.md
+++ b/lists/interop-migration.md
@@ -4,7 +4,7 @@
 
 Bridges to and from Claude Code, Codex, and other harnesses.
 
-92 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+93 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -42,6 +42,7 @@ Bridges to and from Claude Code, Codex, and other harnesses.
 | dsh-codex-agent-bridge | 2 | [je00/dsh-codex-agent-bridge](https://github.com/je00/dsh-codex-agent-bridge) | Connect DeepSeek Harness agents to authenticated Codex App Server sessions | 0.1.0-rc.6 (2026-08-14) |
 | dsh-codex-auth | 2 | [suntianc/dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) | Use the local Codex CLI ChatGPT login as a DeepSeek Harness LLM route, with a native GPT Auth settings card | 0.1.0-rc.6 (2026-08-15) |
 | dsh-codex-importer | 2 | [life1996cou/dsh-codex](https://github.com/life1996cou/dsh-codex) · [npm](https://www.npmjs.com/package/@deepseek-ai/dsh-codex-importer) | 从本地 Codex (~/.codex) 导入会话，生成带完整历史的新 DSH 会话 | 0.1.0-rc.6 (2026-08-14) |
+| dsh-cxsm | 2 | [negativegluon/dsh-cxsm](https://github.com/negativegluon/dsh-cxsm) | Codex-style conversation summary tab for DeepSeek Harness (DSH). | 0.1.0-rc.6 (2026-08-15) |
 | dsh-deck-builder | 2 | [Blaczz/dsh-deck-builder](https://github.com/Blaczz/dsh-deck-builder) | DeepSeek Harness tool plugin: convert Markdown into a self-contained HTML presentation (slides) with themes and keyboard navigation. Zero dependencies, no core changes. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-file-mention-hucj09 | 2 | [hucj09/dsh-file-mention](https://github.com/hucj09/dsh-file-mention) | DSH Web GUI @-mention workspace file picker: input @ to filter git-tracked files plus files re-included via .aiinclude, like Codex/Claude Code file references. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-find-skill | 2 | [Moximxxx/dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | Bridge the vercel-labs/skills ecosystem into dsh: LLM-driven skill search, install, and lifecycle for temp/project/global scopes | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/knowledge-research.md
+++ b/lists/knowledge-research.md
@@ -4,7 +4,7 @@
 
 Research workbenches, RAG, learning modes.
 
-86 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+87 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -78,6 +78,7 @@ Research workbenches, RAG, learning modes.
 | dsh-geo | 0 | [winyh/dsh-geo](https://github.com/winyh/dsh-geo) | 生成式引擎优化（GEO）DeepSeek Harness plugin for SEO, GEO and AEO analysis of Markdown knowledge bases. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-llm-wiki-wangning | 0 | [wangning19940904/dsh-llm-wiki](https://github.com/wangning19940904/dsh-llm-wiki) | Workspace-scoped, local-first LLM wiki plugin for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-github-search | 0 | [Tianbaidi/dsh-plugin-github-search](https://github.com/Tianbaidi/dsh-plugin-github-search) | Search GitHub repos and npm packages before building new dsh plugins — stop reinventing wheels | 0.1.0-rc.6 (2026-08-15) |
+| dsh-plugin-kaoyan | 0 | [luyyooo/dsh-plugin-kaoyan](https://github.com/luyyooo/dsh-plugin-kaoyan) | Postgraduate-exam study workbench in the sidebar: task board, mistake book with AI classification, reading drills, vocabulary, essay marking, and a politics monthly digest. | unverified |
 | dsh-plugin-search | 0 | [shinjiyu/dsh-plugin-search](https://github.com/shinjiyu/dsh-plugin-search) | Zero-config web_search for DeepSeek Harness when you are not on the official DeepSeek API. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-project-wiki | 0 | [yu-xin-c/dsh-project-wiki](https://github.com/yu-xin-c/dsh-project-wiki) | Auditable, workspace-local project wiki for DeepSeek Harness with a native Web view | 0.1.0-rc.6 (2026-08-15) |
 | dsh-research-library | 0 | [LKRCharon/dsh-research-library](https://github.com/LKRCharon/dsh-research-library) | A native research-library workbench for DeepSeek Harness, powered by Field Current: bounded literature search, BibTeX, and session-linked evidence snapshots. | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/memory-sessions.md
+++ b/lists/memory-sessions.md
@@ -4,7 +4,7 @@
 
 Memory systems, context management, session search/rewind/export.
 
-273 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+275 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -270,6 +270,7 @@ Memory systems, context management, session search/rewind/export.
 | dsh-skill-trail | 0 | [Bryan-cmf/dsh-skill-trail](https://github.com/Bryan-cmf/dsh-skill-trail) | DSH-Plugin: per-reply skill trail — truthful per-turn triggered/used tool & skill badges, folded from the session log (no model self-reporting). | 0.1.0-rc.6 (2026-08-15) |
 | dsh-subagent-model-selector | 0 | [qwased/dsh-subagent-model-selector](https://github.com/qwased/dsh-subagent-model-selector/tree/HEAD/packages/client/ui-subagent-model) | Subagent model pinning UI: the /subagent-model popupSelect over the session model directory | 0.1.0-rc.6 (2026-08-15) |
 | dsh-task-console | 0 | [He2way/dsh-task-console](https://github.com/He2way/dsh-task-console) | DSH client plugin — flip to the back of the page for a floating glass task console: live background jobs, subagents, session overview and workspace of the current session, with mouse-draggable cards. | 0.1.0-rc.6 (2026-08-15) |
+| dsh-timeline-hemo9493 | 0 | [hemo94931/dsh-timeline](https://github.com/hemo94931/dsh-timeline) | 会话时间轴：在 dsh WebUI 会话消息列右缘渲染用户消息刻度导航条（悬浮摘要 / 点击跳转 / ▲▼ 导航 / 连续位置指示） | 0.1.0-rc.6 (2026-08-15) |
 | dsh-token-viewer | 0 | [qwert702/dsh-token-viewer](https://github.com/qwert702/dsh-token-viewer) | Token consumption surface: a composer-dock strip for the current session plus a sidebar card above the workspaces region aggregating all sessions, read from the token-meter session projections | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tool-memory | 0 | [sikwoxy/dsh-tool-memory](https://github.com/sikwoxy/dsh-tool-memory) | DeepSeek Harness 插件：Hermes 式跨会话持久记忆。MEMORY.md/USER.md 纯文本存储 + 冻结快照注入 system prompt + memory_* 工具（add/replace/remove/batch/show/refresh） | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tools-meta | 0 | [DViridescent/dsh-tools-meta](https://github.com/DViridescent/dsh-tools-meta) | 允许 agent 在 DSH 里为自己动态增删工具。新增的工具可以跨 DSH 重启存在。Let the agent add and remove tools for itself in DSH; added tools persist across DSH restarts. | 0.1.0-rc.6 (2026-08-15) |
@@ -278,6 +279,7 @@ Memory systems, context management, session search/rewind/export.
 | dsh-ux-plugins | 0 | [Kutlukgit/dsh-ux-plugins](https://github.com/Kutlukgit/dsh-ux-plugins/tree/HEAD/packages/ux/session-title) | Auto-generate concise session titles from the first user message in DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-vector-memory | 0 | [Bryan-cmf/dsh-vector-memory](https://github.com/Bryan-cmf/dsh-vector-memory) | DSH-Plugin: durable agent memory core — mem_save / mem_search / mem_health tools backed by the DSH storageDomain (durable, survives restarts), plus a 記憶 view tab. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-workspace-enhance | 0 | [yuanzehui313/dsh-workspace-enhance](https://github.com/yuanzehui313/dsh-workspace-enhance) | DeepSeek Harness workspace & session enhancement plugin: recycle bin, cross-workspace session drag, ungrouped sessions, multi-folder workspace roots, in-app directory picker, session merge — shipped | 0.1.0-rc.6 (2026-08-15) |
+| omp2dsh-plugins | 0 | [Fun10165/omp2dsh-plugins](https://github.com/Fun10165/omp2dsh-plugins/tree/HEAD/packages/bang) | ! prefix quick command runner: !cmd injects its result into the session flow (context), !!cmd shows it in a dock panel marked excluded-from-context. Ported from omp's bang/bash input modes. | 0.1.0-rc.6 (2026-08-15) |
 | pi-dsh | 0 | [fatwang2/pi-dsh](https://github.com/fatwang2/pi-dsh) | Pi Coding Agent provider extension that exposes the DeepSeek Harness (dsh) as a selectable provider: in-process session pool with live streaming; DSH owns prompt/memory/skills, pi-dsh routes each | 0.1.0-rc.6 (2026-08-15) |
 | session-import-codex | 0 | [xing01l/session-import-codex](https://github.com/xing01l/session-import-codex) | DeepSeek Harness plugin for importing Codex App Server conversation history | 0.1.0-rc.6 (2026-08-15) |
 | ThreadTrail | 0 | [drindr/ThreadTrail](https://github.com/drindr/ThreadTrail/tree/HEAD/threadtrail-client) | ThreadTrail browser panel for DeepSeek Harness: the operation timeline between commits, message -> diff, code -> conversation, and non-destructive rewind. | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/notifications.md
+++ b/lists/notifications.md
@@ -4,7 +4,7 @@
 
 Alerting the human: desktop, sound, even a phone call.
 
-39 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+40 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -42,6 +42,7 @@ Alerting the human: desktop, sound, even a phone call.
 | dsh-notify-dshiq04 | 0 | [dshiq04/dsh-notify](https://github.com/dshiq04/dsh-notify) | Browser notifications + distinct chimes for the dsh web UI: alerted when a run finishes and when the agent needs user input (question / plan review / approval), each with its own clearly different | 0.1.0-rc.6 (2026-08-15) |
 | dsh-notify-zhengjy0 | 0 | [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) | 系统级弹窗提示插件：任务完成 / 任务失败 / 工具失败 / 目标完成或受阻 / 工作流完成 / 需要人工确认（权限审批）时弹出系统通知（macOS 通知中心横幅与模态弹窗，Linux notify-send） | 0.1.0-rc.6 (2026-08-15) |
 | dsh-peak-alert | 0 | [zbxzbx98/dsh-peak-alert](https://github.com/zbxzbx98/dsh-peak-alert) | DeepSeek 峰谷定价提示插件：高峰时段（北京 09:00-12:00 / 14:00-18:00）把 DSH Web 输入卡片染成淡红色，并显示当前高峰/空闲时段、价格倍率与下次切换时间 | 0.1.0-rc.6 (2026-08-15) |
+| dsh-plugin-notification-sounds | 0 | [Heldea-xianmiao/dsh-plugin-notification-sounds](https://github.com/Heldea-xianmiao/dsh-plugin-notification-sounds) | DSH 提示音插件（原生常驻版）：为开始运行、成功完成、异常中断、需要审批、子代理完成等事件分别设置提示音，支持逐事件上传本地音频文件。 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-onebot | 0 | [kun2-5code/dsh-plugin-onebot](https://github.com/kun2-5code/dsh-plugin-onebot) | DeepSeek Harness (dsh) plugin: notify OneBot users/groups when a task completes, via WS long-connection (server mode) + OneBot HTTP API actions. Config editable in the web GUI (Settings → Plugins → | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-web-notify | 0 | [vilicvane/dsh-plugin-web-notify](https://github.com/vilicvane/dsh-plugin-web-notify) | Browser notifications for DeepSeek Harness: turn completion, approvals, plan reviews, and questions. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-push | 0 | [kiim-wong/dsh-push](https://github.com/kiim-wong/dsh-push) | Push DeepSeek Harness agent lifecycle notifications to configurable channels | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/plugin-managers-stores.md
+++ b/lists/plugin-managers-stores.md
@@ -4,7 +4,7 @@
 
 In-UI stores, installers, skill managers.
 
-122 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+123 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -66,6 +66,7 @@ In-UI stores, installers, skill managers.
 | dsh-store | 3 | [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) · [npm](https://www.npmjs.com/package/dsh-store) | DeepSeek Harness 插件商店：npm 权威源聚合（250+ 插件）+ dsh 字段质量验证 + GitHub 星标，一键安装/卸载（自动合并 cordis.patch.yml），重启生效。 | 0.1.0-rc.6 (2026-08-14) |
 | dsh-web | 3 | [Tom6814/dsh-web](https://github.com/Tom6814/dsh-web/tree/HEAD/plugin-market) | DSH 插件市场 + 预览面板 + 插件启停：搜索安装 GitHub topic:dsh-plugin 插件；对话文件/端口网页预览；插件列表启用停用（Zeabur 适配） | 0.1.0-rc.6 (2026-08-15) |
 | dsh-workshop | 3 | [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) | Steam Workshop style plugin store for DSH Web UI: browse, search and one-click install community plugins with mirror acceleration | 0.1.0-rc.6 (2026-08-14) |
+| deepseek-harness-desktop-evanmorm | 2 | [evanmormmm/deepseek-harness-desktop](https://github.com/evanmormmm/deepseek-harness-desktop) | Community Windows desktop distribution of DeepSeek Harness with a verified installer and portable runtime. | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-huggingface | 2 | [emredeveloper/deepseek-harness-huggingface](https://github.com/emredeveloper/deepseek-harness-huggingface) | DeepSeek Harness tools for discovering models on Hugging Face Hub. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-better-launcher | 2 | [mocchh/dsh-better-launcher](https://github.com/mocchh/dsh-better-launcher) | dsh start / stop / status — one-command lifecycle manager for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-dynplugin-manager | 2 | [Thomas-key/dsh-dynplugin-manager](https://github.com/Thomas-key/dsh-dynplugin-manager) · [npm](https://www.npmjs.com/package/dsh-dynplugin-manager) | Manage DSH dynamic plugins (Dynamic Cordis Plugins): scan directories, browse, and load via /dynload slash command. Community gap — self-built. | 0.1.0-rc.6 (2026-08-14) |

--- a/lists/terminals-desktop.md
+++ b/lists/terminals-desktop.md
@@ -4,7 +4,7 @@
 
 TUIs, desktop shells, headless runners.
 
-111 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+116 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -14,6 +14,7 @@ TUIs, desktop shells, headless runners.
 | dsh-desktop | 210 | [dataelement/dsh-desktop](https://github.com/dataelement/dsh-desktop) | A cross-platform desktop shell for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tianshu-tui | 143 | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) · [npm](https://www.npmjs.com/package/@huiliyi37/dsh-tianshu-tui) | Terminal UI for dsh shipped as an installable profile bundle | 0.1.0-rc.5 (2026-08-13) |
 | deepseek-harness-desktop-ningbain | 39 | [ningbainb/deepseek-harness-desktop](https://github.com/ningbainb/deepseek-harness-desktop/tree/HEAD/apps/dsh-desktop) | Lossless desktop shell for DeepSeek Harness and the complete dsh-web-ui plugin collection | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-app | 27 | [RongleCat/deepseek-app](https://github.com/RongleCat/deepseek-app) | Desktop workbench for DeepSeek Harness — Grok App visual shell, DSH engine | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-tui-openmaai | 25 | [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui/tree/HEAD/npm) | Terminal-native agent UI for DeepSeek Harness; standalone CLI or dsh profile bundle | 0.1.0-rc.6 (2026-08-15) |
 | DSHDesktop | 21 | [CCMu04/DSHDesktop](https://github.com/CCMu04/DSHDesktop) | Unofficial Windows desktop shell for the unmodified DeepSeek Harness Web UI | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-cc1252 | 17 | [cc1252/deepseek-harness-desktop](https://github.com/cc1252/deepseek-harness-desktop/tree/HEAD/harness) | Unpruned runtime payload for the Electron wrapper | 0.1.0-rc.6 (2026-08-15) |
@@ -30,6 +31,7 @@ TUIs, desktop shells, headless runners.
 | dsh-desktop-ethanwea | 5 | [ethanweave/dsh-desktop](https://github.com/ethanweave/dsh-desktop/tree/HEAD/runtime) | DeepSeek Harness 桌面应用（类 Codex）：原生窗口 + 系统托盘 | 0.1.0-rc.6 (2026-08-15) |
 | DSH-Plugs | 5 | [JustGenius-s/DSH-Plugs](https://github.com/JustGenius-s/DSH-Plugs/tree/HEAD/plugins/dsh-desktop-update) | Desktop update badge for DSH-Desktop: renders an update icon next to the sidebar Settings button, driven by window.dshDesktop (Electron preload bridge) | 0.1.0-rc.6 (2026-08-15) |
 | Deepseek-Harness-as-Desktop | 4 | [KhanZou/Deepseek-Harness-as-Desktop](https://github.com/KhanZou/Deepseek-Harness-as-Desktop/tree/HEAD/dsh-desktop-framework) | Unified desktop framework for the DSH Web UI: generic settings tabs/items (window.__DSH_SETTINGS__), right/bottom panel shells (window.__DSH_PANELS__), and the Files/Changes/Terminal tabs with | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-harness-desktop-bailang1 | 4 | [bailang1218/deepseek-harness-desktop](https://github.com/bailang1218/deepseek-harness-desktop) | Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-tui | 4 | [Hilbert-beinghappy/deepseek-tui](https://github.com/Hilbert-beinghappy/deepseek-tui) | A pluggable DeepSeek-colored terminal surface for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 | dib | 4 | [MaimoryLab/dib](https://github.com/MaimoryLab/dib/tree/HEAD/plugins/dsh-desktop) | DeepSeek Harness desktop UI extensions | 0.1.0-rc.6 (2026-08-15) |
 | DSH-closerAI | 4 | [sb1733831438-maker/DSH-closerAI](https://github.com/sb1733831438-maker/DSH-closerAI/tree/HEAD/apps/desktop) | CloserAI Electron desktop shell: hardened window that hosts the DeepSeek Harness web UI. | 0.1.0-rc.6 (2026-08-15) |
@@ -72,6 +74,7 @@ TUIs, desktop shells, headless runners.
 | dsh-tui-rabbitkn | 2 | [rabbitknight/dsh-tui](https://github.com/rabbitknight/dsh-tui/tree/HEAD/packages/dsh-tui-app) | The dsh terminal-surface bundle: an interactive TUI over dsh-base, ported from pi's terminal UI (@earendil-works/pi-tui) | 0.1.0-rc.6 (2026-08-15) |
 | maid-atelier-ui-bundle | 2 | [flaricy/maid-atelier-ui-bundle](https://github.com/flaricy/maid-atelier-ui-bundle/tree/HEAD/plugins/dsh-side-panel) | Git review, terminal, and file workspace panel for DSH Web | 0.1.0-rc.6 (2026-08-15) |
 | dash-songqiko | 1 | [songqikong/dash](https://github.com/songqikong/dash) | DASH — Deepseek Agentic Service Harness. oh-my-pi style TUI on the DSH agent kernel, run in the terminal via `dsh --profile dash`. | 0.1.0-rc.6 (2026-08-15) |
+| deepseek-harness-desktop-0reki | 1 | [0reki/deepseek-harness-desktop](https://github.com/0reki/deepseek-harness-desktop) | Native desktop client for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-community | 1 | [k4its1t/deepseek-harness-desktop-community](https://github.com/k4its1t/deepseek-harness-desktop-community/tree/HEAD/runtime) | An unofficial open-source desktop shell for the DeepSeek Harness Web UI on macOS and Windows. | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-dawnmagn | 1 | [DawnMagnet/deepseek-harness-desktop](https://github.com/DawnMagnet/deepseek-harness-desktop) | A simple Windows desktop launcher for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-jesspig | 1 | [jesspig/deepseek-harness-desktop](https://github.com/jesspig/deepseek-harness-desktop/tree/HEAD/packages/desktop-bundle) | 这是一个独立的 Cordis 应用:不改动上游仓库,以官方扩展方式(自定义 profile + bundle + Cordis 插件)把 dsh 跑成原生桌面应用。 | 0.1.0-rc.6 (2026-08-15) |
@@ -82,6 +85,7 @@ TUIs, desktop shells, headless runners.
 | deepseek-harness-desktop-phoenix0 | 1 | [phoenix0086/deepseek-harness-desktop](https://github.com/phoenix0086/deepseek-harness-desktop) | Unofficial macOS desktop distribution for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-windows | 1 | [Easyhoov/deepseek-harness-desktop-windows](https://github.com/Easyhoov/deepseek-harness-desktop-windows) | DeepSeek Harness as a desktop app: host boots in-process inside Electron, the built frontend loads locally, and API plus event traffic crosses an IPC bridge (no port, no local HTTP server). | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-harness-desktop-xiangsha | 1 | [xiangshangya/deepseek-harness-desktop](https://github.com/xiangshangya/deepseek-harness-desktop) | Electron desktop app for the DeepSeek Harness — bundles the dsh web server and its web frontend. | 0.1.0-rc.6 (2026-08-15) |
+| DeepSeek-Harness-Electron- | 1 | [FlyPig-tt/DeepSeek-Harness-Electron-](https://github.com/FlyPig-tt/DeepSeek-Harness-Electron-) | DeepSeek Harness 的 Electron 桌面版 | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-HARNESS-GUI | 1 | [MoRiv447/deepseek-HARNESS-GUI](https://github.com/MoRiv447/deepseek-HARNESS-GUI) | Tauri 2 desktop wrapper for DeepSeek Harness (dsh) — double-click to launch the local web UI, no CLI needed | 0.1.0-rc.6 (2026-08-15) |
 | desktop-gui-automation-cua | 1 | [afa-cloud/desktop-gui-automation-cua](https://github.com/afa-cloud/desktop-gui-automation-cua/tree/HEAD/plugin) | DSH plugin shell for desktop-gui-automation-cua: slash commands that drive the repo's computer-use scripts (single source of truth). | 0.1.0-rc.6 (2026-08-15) |
 | desktop-harness | 1 | [citizenll/desktop-harness](https://github.com/citizenll/desktop-harness) | Electron desktop distribution of DeepSeek Harness with source-driven evolution and plugin management. | 0.1.0-rc.6 (2026-08-15) |
@@ -92,6 +96,7 @@ TUIs, desktop shells, headless runners.
 | dsh-desktop-qingchun | 1 | [qingchunnh/dsh-desktop](https://github.com/qingchunnh/dsh-desktop) | DeepSeek Harness 的桌面客户端，自动检测本机运行环境，启动并连接 dsh Web UI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-desktop-shell | 1 | [ikashana/dsh-desktop-shell](https://github.com/ikashana/dsh-desktop-shell) | Desktop launcher shell for DeepSeek Harness (dsh): a tray-resident Electron wrapper that starts or reuses the local dsh web server and opens it in a native window | 0.1.0-rc.6 (2026-08-15) |
 | dsh-desktop-window | 1 | [fengzhiyushui/dsh-desktop-window](https://github.com/fengzhiyushui/dsh-desktop-window) | DSH 桌面窗口插件：以独立应用窗口打开 DeepSeek Harness Web UI（自动开窗 + 会话头部手动开关 + 设置页自动开窗开关） | 0.1.0-rc.6 (2026-08-15) |
+| dsh-desktop-xenia092 | 1 | [Xenia0922/dsh-desktop](https://github.com/Xenia0922/dsh-desktop) | DeepSeek Harness desktop application | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tui-xiaoshih | 1 | [xiaoshihou514/dsh-tui](https://github.com/xiaoshihou514/dsh-tui) | An interactive terminal surface for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-web-open-bnqzzdf | 1 | [bnqzzdf/dsh-web-open](https://github.com/bnqzzdf/dsh-web-open) | Auto-open the browser, whale tray icon, desktop shortcut and one-shot installer for `dsh web` (DeepSeek Harness plugin) | 0.1.0-rc.6 (2026-08-15) |
 | dsh-windows-tray | 1 | [GZMULDY/dsh-windows-tray](https://github.com/GZMULDY/dsh-windows-tray) · [npm](https://www.npmjs.com/package/@gzmuldyxx/dsh-windows-tray) | System-tray whale controller for DeepSeek Harness (Windows): Start / Stop / Restart the dsh web service and open the Web UI from a tray icon. | 0.1.0-rc.6 (2026-08-14) |

--- a/lists/usage-cost.md
+++ b/lists/usage-cost.md
@@ -4,7 +4,7 @@
 
 Token accounting, billing, balance, quota.
 
-198 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+200 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -202,7 +202,9 @@ Token accounting, billing, balance, quota.
 | dsh-tools | 0 | [HarryLi-7/dsh-tools](https://github.com/HarryLi-7/dsh-tools/tree/HEAD/dsh-balance-widget) | Show DeepSeek account balance in the DSH web composer input row | 0.1.0-rc.6 (2026-08-15) |
 | dsh-turn-budget-nunchaku | 0 | [Nunchakus888/dsh-turn-budget](https://github.com/Nunchakus888/dsh-turn-budget) | Fail-closed per-turn step, tool-call, and provider-token budgets for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-turn-usage | 0 | [HABIDSKOFT/dsh-turn-usage](https://github.com/HABIDSKOFT/dsh-turn-usage) | Per-turn token usage and cost display for the DeepSeek Harness web UI: input (cache miss/hit), output, and estimated price per conversation. dsh-plugin. | 0.1.0-rc.6 (2026-08-15) |
+| dsh-usage-meter-hohband | 0 | [hohband/DSH-Plugins](https://github.com/hohband/DSH-Plugins/tree/HEAD/usage-meter) | Sidebar balance and usage readout for two providers at once: DeepSeek official and OpenCode Go. | unverified |
 | dsh-usage-meter-vdev388 | 0 | [V-dev-388/dsh-usage-meter](https://github.com/V-dev-388/dsh-usage-meter) | DSH（DeepSeek Harness）模型用量仪表盘插件：按服务商/模型汇总全部会话 token 用量（assistant/message 带 usage 事件），设置页「用量」板块展示，含今日/7天/30天趋势柱状图。 | 0.1.0-rc.6 (2026-08-15) |
 | LastTokens | 0 | [SynetAI/LastTokens](https://github.com/SynetAI/LastTokens) | 实时显示 DeepSeek API 余额、任务消耗记录（tokens 消耗量 / 缓存命中 / 耗时 / 估算金额）， 可拖动悬浮球 + 四主题悬浮仪表盘。 | 0.1.0-rc.6 (2026-08-15) |
+| opencode-go-usage-badge | 0 | [UniverseCA/opencode-go-usage-badge](https://github.com/UniverseCA/opencode-go-usage-badge) | OpenCode Go subscription usage as a badge in the conversation header, with a click-to-open rolling/weekly/monthly detail card. | unverified |
 | ui-theme-quota-show | 0 | [wwxiaoqi/ui-theme-quota-show](https://github.com/wwxiaoqi/ui-theme-quota-show) | DeepSeek Harness web UI plugin: a sidebar card above Settings that shows the live DeepSeek API balance (total / topped-up / granted, period usage, low-balance warning) from the official GET | 0.1.0-rc.6 (2026-08-15) |
 | uiopt | 0 | [237229953-create/uiopt](https://github.com/237229953-create/uiopt) | 显示优化 — WebUI 显示增强:余额实时查询、会话消耗、缓存命中率、提供商图标、额外插件管理 | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/vision.md
+++ b/lists/vision.md
@@ -4,7 +4,7 @@
 
 Image understanding for text-only models.
 
-140 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+141 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -123,6 +123,7 @@ Image understanding for text-only models.
 | dsh-image-to-text | 0 | [HiSeax/dsh-image-to-text](https://github.com/HiSeax/dsh-image-to-text) | DSH model tool that converts images to text (OCR + description) via configurable vision API providers, with image intake support for text-only models. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-imagegen-plugin | 0 | [ShiXiangYu2/dsh-imagegen-plugin](https://github.com/ShiXiangYu2/dsh-imagegen-plugin) | A DeepSeek Harness plugin that registers a generate_image tool (Qwen-Image / DeepSeek Janus-Pro-7B via SiliconFlow) callable by the model. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-llm-vision-router | 0 | [dmsobtl/dsh-llm-vision-router](https://github.com/dmsobtl/dsh-llm-vision-router) | DSH plugin: auto-route to a multimodal model when messages contain images, stay on the cheap model otherwise. | 0.1.0-rc.6 (2026-08-15) |
+| dsh-multimedia-viewer | 0 | [chaiyujin/dsh-multimedia-viewer](https://github.com/chaiyujin/dsh-multimedia-viewer) | Browse images and video from the current workspace inside the harness page: floating button, filtered thumbnail grid, lightbox and inline playback. Scoped to the session cwd. | unverified |
 | DSH-Multimodal-yauntyou | 0 | [yauntyour/DSH-Multimodal](https://github.com/yauntyour/DSH-Multimodal) | DSH multimodal input plugin: route file attachments (images, video, audio, text) through per-preset model chains and feed the results to the session model as prompt tokens. Adds a Multimodal settings | 0.1.0-rc.6 (2026-08-15) |
 | dsh-ocr-review | 0 | [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) | Local OpenCodeReview (ocr) gate for dsh: ocr_review tool runs AI code review on a workspace/branch diff via the managed node install, returns structured findings and optional gate failure. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-onebot-mario841 | 0 | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ bot channel for dsh via the OneBot 11 protocol (NapCat / Lagrange / LLOneBot / go-cqhttp): reverse- or forward-WebSocket, DM + group chats with mention gating and allowlists, inbound image/voice | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/web-ui.md
+++ b/lists/web-ui.md
@@ -4,7 +4,7 @@
 
 Panels, composer upgrades, navigation, layout, mobile.
 
-267 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+269 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -246,6 +246,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-git-graph-samecorn | 0 | [samecorner/dsh-git-graph](https://github.com/samecorner/dsh-git-graph) | GitKraken / vscode-git-graph style commit graph for dsh: a server-side tool pair (git_graph / git_show) plus keyed tool views that render the commit DAG, refs, and per-commit diffs right inside the | 0.1.0-rc.6 (2026-08-15) |
 | dsh-hotswap | 0 | [HongzhongL/dsh-hotswap](https://github.com/HongzhongL/dsh-hotswap) | Runtime hot-swap for DeepSeek Harness: hot enable/disable/restart Cordis plugins and auto hot-mount bundles from the Web GUI — no dsh restart. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-lan-uuid-fix | 0 | [Zenjibad/dsh-lan-uuid-fix](https://github.com/Zenjibad/dsh-lan-uuid-fix) | dsh bundle: polyfill crypto.randomUUID on insecure origins so the DeepSeek Harness Web UI works over plain-HTTP LAN | 0.1.0-rc.6 (2026-08-15) |
+| dsh-locale-ja | 0 | [fang2hou/dsh-locale-ja](https://github.com/fang2hou/dsh-locale-ja) | Japanese (日本語) interface for DeepSeek Harness — a standard DSH client plugin that adds 日本語 as a selectable UI language alongside 中文 and English, with Japanese system fonts. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-markdown-preview | 0 | [GitHubJiKe/dsh-markdown-preview](https://github.com/GitHubJiKe/dsh-markdown-preview) | In-chat preview for produced files in DeepSeek Harness Web: click a produced-file chip to render Markdown (server-side markdown-it + highlight.js), images, or plain text right in the conversation | 0.1.0-rc.6 (2026-08-15) |
 | dsh-mermaid-preview | 0 | [realguan/dsh-mermaid-preview](https://github.com/realguan/dsh-mermaid-preview) | Render Mermaid fenced code blocks as diagrams in DeepSeek Harness (dsh) web — chat, trajectory, plan review and every other Markdown surface. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-mermaid-preview-plugin | 0 | [baconbao/dsh-mermaid-preview-plugin](https://github.com/baconbao/dsh-mermaid-preview-plugin) | Render mermaid fenced blocks inside assistant messages as diagrams directly in the chat. | 0.1.0-rc.6 (2026-08-15) |
@@ -253,6 +254,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-navigation-bar | 0 | [KeLearns/dsh-navigation-bar](https://github.com/KeLearns/dsh-navigation-bar) | Piano-key style conversation navigation bar for the DeepSeek Harness web GUI: one key per user message with hover ladder animation, message-preview tooltip and active-message highlight. Official | 0.1.0-rc.6 (2026-08-15) |
 | dsh-open-with | 0 | [ChuanTianML/dsh-open-with](https://github.com/ChuanTianML/dsh-open-with) | Open registered DeepSeek Harness workspaces in detected or configured local editors from the Web GUI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-api-quota | 0 | [ganfne123/dsh-plugin-api-quota](https://github.com/ganfne123/dsh-plugin-api-quota) | DSH Web UI plugin: check your DeepSeek API key balance/quota (GET /user/balance) from the sidebar, with a GUI panel showing total/granted/topped-up balance. | 0.1.0-rc.6 (2026-08-15) |
+| dsh-plugin-bgpic | 0 | [luyyooo/dsh-plugin-bgpic](https://github.com/luyyooo/dsh-plugin-bgpic) | Background image control in the top-right: local or URL images, custom cropping, opacity and surface translucency, ordered or random slideshow. | unverified |
 | dsh-plugin-checker | 0 | [Airmetro/dsh-plugin-checker](https://github.com/Airmetro/dsh-plugin-checker) | Detect updates for installed third-party (non-builtin) DSH plugins, ask the user, and update them from the Web GUI. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-connection-banner | 0 | [yinren112/dsh-plugin-connection-banner](https://github.com/yinren112/dsh-plugin-connection-banner) | Visible reconnecting banner for the DeepSeek Harness Web UI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-doc-present | 0 | [AuraxM/dsh-plugin-doc-present](https://github.com/AuraxM/dsh-plugin-doc-present) | Doc Present: let the agent present plans/designs as self-contained interactive HTML pages (FX animations) - shown in an in-GUI panel and a shareable LAN preview server instead of long chat text | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
Registry 2,642 → 2,662. More interesting than the count: **a class of dsh extension that every gate we have passes over.**

## The dynamic Cordis plugin

Triaging `wangjacks/dsh-hanami-theme` in the themes repo turned this up. It has no `package.json`, no manifest, no npm package. You install it by opening a 创造模式 (cordis preset) session and calling `cordis_define` with the client file as `code.client`, then `cordis_run` on the returned plugin id. It lives in the process — a page refresh drops it and you re-activate by pasting the id back.

Our gates look for: a root `package.json` with a `dsh` manifest, a nested one, a `SKILL.md`, or a `--dsw-*` stylesheet. A dynamic plugin has **none of those**. It is structurally invisible to the sweep, and it is invisible to the `dsh-plugin` topic too, because these authors are publishing source backups rather than installable packages.

## How big is the hole

GitHub code search for `cordis_define`: **605 hits**. Sampling 300 → 67 distinct repositories → **32 in neither registry nor the rejection ledger**. Running the usual two-stage gate over those 32:

| outcome | n |
|---|---|
| real install path at the root | 12 |
| real install path in a subdirectory | 3 |
| **dynamic Cordis plugin, no manifest anywhere** | **6** |
| rejected | 11 |

The 11 rejects: 4 vendored clones of the harness itself (`deepseek-harness/apps/cli` sitting inside a desktop wrapper), a plugin-discovery site, a native macOS client, and 5 with no dsh install path. Vendored clones and the discovery site are judgment calls, so permanent; the rest carry `recheckAfter`.

## On `status: unverified` for the six

Deliberate. `schema.json` defines `verified` as "install path confirmed — manifest or skill-layout inspection at minimum", and a dynamic plugin has neither to inspect. I read their sources and READMEs and believe them; that is not the same thing, and under-claiming beats a flattering field. If you activate one, flip it and say so.

They are not toys:

- **`luyyooo/dsh-plugin-kaoyan`** — postgraduate-exam workbench: task board, mistake book with AI classification and duplicate detection, 2010–2026 reading drills scraped and marked, vocabulary, essay marking, a monthly politics digest built from web search.
- **`linkage18/donecheck`** — automatic review-and-repair loop. The reviewer sees the full reply *plus the actual tool results* and iterates with tool access until the work is really done. Written specifically against the failure mode where a fast model stops early believing it finished.
- **`chaiyujin/dsh-multimedia-viewer`**, **`hohband/DSH-Plugins`** (usage-meter), **`UniverseCA/opencode-go-usage-badge`**, **`luyyooo/dsh-plugin-bgpic`**.

Two of the six carry mis-encoded GitHub descriptions (`DSH ??????:???????`), so their descriptions here are written from their READMEs — which is what the [mis-encoding guard](https://github.com/dshworks/awesome-dsh-plugins/pull/32) is for.

## Follow-up, not in this PR

`scripts/discover.mjs` has a `fromCodeSearch()` that only queries `filename:SKILL.md path:.agents/skills`. On this evidence it should also query `cordis_define`. Separate PR — and it needs thought, because code search rations hard (10 req/min) and returns files, not repos.

`node scripts/validate.mjs` → ok (2662 plugins, 248 candidates, 772 rejected).