### PR TITLE
Add dsh-ui-hub to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2755 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2756 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -74,7 +74,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2648 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
+2649 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dshworks.github.io/awesome-dsh-plugins/) always hold everything.
 
@@ -110,7 +110,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-qq2006 | 10 | [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 skin plugin for DSH (DeepSeek Harness): registers the 'qq2006' theme (coral-blue --dsw-alias-* token overrides), mirrors the active theme onto body[data-ds-skin], and ships the global | 0.1.0-rc.6 (2026-08-15) |
 | dsh-web-mobile | 10 | [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) | Mobile-adaptive DSH web UI: on narrow screens the sidebar rail is hidden and the directory opens as an overlay drawer, so the conversation gets the full width. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 284. **[all 284 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 285. **[all 285 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Terminals & desktop
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48864,6 +48864,22 @@
       "stars": 0,
       "starsUpdated": "2026-08-15",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-ui-hub",
+      "repo": "Han-1413141/dsh-ui-hub",
+      "description": "UI butler for every plugin UI in the DSH Web client: official/plugin categories, per-widget toggles, drag move/resize, collision avoidance and one-click auto arrange.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 }

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48864,6 +48864,22 @@ window.__PLUGINS__ = {
       "stars": 0,
       "starsUpdated": "2026-08-15",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-ui-hub",
+      "repo": "Han-1413141/dsh-ui-hub",
+      "description": "UI butler for every plugin UI in the DSH Web client: official/plugin categories, per-widget toggles, drag move/resize, collision avoidance and one-click auto arrange.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48864,6 +48864,22 @@
       "stars": 0,
       "starsUpdated": "2026-08-15",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-ui-hub",
+      "repo": "Han-1413141/dsh-ui-hub",
+      "description": "UI butler for every plugin UI in the DSH Web client: official/plugin categories, per-widget toggles, drag move/resize, collision avoidance and one-click auto arrange.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 }

--- a/lists/web-ui.md
+++ b/lists/web-ui.md
@@ -4,7 +4,7 @@
 
 Panels, composer upgrades, navigation, layout, mobile.
 
-284 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+285 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -284,6 +284,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-turn-diff | 0 | [2436238575/dsh-turn-diff](https://github.com/2436238575/dsh-turn-diff) | DSH Web UI 插件：每轮结束时汇总本轮所有文件修改差异 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-turn-dots | 0 | [Blaczz/dsh-turn-dots](https://github.com/Blaczz/dsh-turn-dots) | Codex-style conversation turn rail: one dot per turn in the DeepSeek Harness web GUI. | 0.1.0-rc.6 (2026-08-14) |
 | Dsh-UI-Enhance | 0 | [xjackzenvey/Dsh-UI-Enhance](https://github.com/xjackzenvey/Dsh-UI-Enhance) | Optional Web UI enhancements for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
+| dsh-ui-hub | 0 | [Han-1413141/dsh-ui-hub](https://github.com/Han-1413141/dsh-ui-hub) | UI butler for every plugin UI in the DSH Web client: official/plugin categories, per-widget toggles, drag move/resize, collision avoidance and one-click auto arrange. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-ux-simple | 0 | [KhalilYamber/dsh-ux-simple](https://github.com/KhalilYamber/dsh-ux-simple) | DSH 界面两档模式（简化/原生）：工具卡片白话化，降低新手门槛 / Two-level UI mode (simple/native) with plain-language tool cards for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-vscode-lonelymo | 0 | [lonelymoon87/dsh-vscode](https://github.com/lonelymoon87/dsh-vscode) | Run DeepSeek Harness sessions from a VS Code sidebar. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-workspace-dir | 0 | [DDSG-X/dsh-workspace-dir](https://github.com/DDSG-X/dsh-workspace-dir) | DeepSeek Harness plugin: show the current conversation's working directory in a draggable directory panel with adjustable opacity. | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
Add dsh-ui-hub to the plugins registry.

- category: plugin
- tags: ui
- verifiedAgainst: 0.1.0-rc.6
- lastVerified: 2026-08-15
- status: verified

Validated with scripts/validate.mjs and rendered with scripts/render.mjs.