### PR TITLE
Add dsh-plugin-open-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2756 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2757 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -74,7 +74,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2649 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
+2650 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dshworks.github.io/awesome-dsh-plugins/) always hold everything.
 
@@ -110,7 +110,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-qq2006 | 10 | [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 skin plugin for DSH (DeepSeek Harness): registers the 'qq2006' theme (coral-blue --dsw-alias-* token overrides), mirrors the active theme onto body[data-ds-skin], and ships the global | 0.1.0-rc.6 (2026-08-15) |
 | dsh-web-mobile | 10 | [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) | Mobile-adaptive DSH web UI: on narrow screens the sidebar rail is hidden and the directory opens as an overlay drawer, so the conversation gets the full width. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 285. **[all 285 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 286. **[all 286 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Terminals & desktop
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48880,6 +48880,21 @@
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-plugin-open-app",
+      "repo": "2nd1st/dsh-plugin-open-app",
+      "npm": "@2nd1st/dsh-plugin-open-app",
+      "description": "Brings open-mcp-apps into dsh: each MCP app becomes a sidebar container with its own workspace, session and App mode, plus an agent status strip and inline widget rendering in chat.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 }

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48880,6 +48880,21 @@ window.__PLUGINS__ = {
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-plugin-open-app",
+      "repo": "2nd1st/dsh-plugin-open-app",
+      "npm": "@2nd1st/dsh-plugin-open-app",
+      "description": "Brings open-mcp-apps into dsh: each MCP app becomes a sidebar container with its own workspace, session and App mode, plus an agent status strip and inline widget rendering in chat.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48880,6 +48880,21 @@
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-plugin-open-app",
+      "repo": "2nd1st/dsh-plugin-open-app",
+      "npm": "@2nd1st/dsh-plugin-open-app",
+      "description": "Brings open-mcp-apps into dsh: each MCP app becomes a sidebar container with its own workspace, session and App mode, plus an agent status strip and inline widget rendering in chat.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "unverified",
+      "tags": [
+        "ui"
+      ]
     }
   ]
 }

--- a/lists/web-ui.md
+++ b/lists/web-ui.md
@@ -4,7 +4,7 @@
 
 Panels, composer upgrades, navigation, layout, mobile.
 
-285 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+286 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -277,6 +277,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-plugin-checker | 0 | [Airmetro/dsh-plugin-checker](https://github.com/Airmetro/dsh-plugin-checker) | Detect updates for installed third-party (non-builtin) DSH plugins, ask the user, and update them from the Web GUI. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-connection-banner | 0 | [yinren112/dsh-plugin-connection-banner](https://github.com/yinren112/dsh-plugin-connection-banner) | Visible reconnecting banner for the DeepSeek Harness Web UI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-plugin-doc-present | 0 | [AuraxM/dsh-plugin-doc-present](https://github.com/AuraxM/dsh-plugin-doc-present) | Doc Present: let the agent present plans/designs as self-contained interactive HTML pages (FX animations) - shown in an in-GUI panel and a shareable LAN preview server instead of long chat text | 0.1.0-rc.6 (2026-08-15) |
+| dsh-plugin-open-app | - | [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) · [npm](https://www.npmjs.com/package/@2nd1st/dsh-plugin-open-app) | Brings open-mcp-apps into dsh: each MCP app becomes a sidebar container with its own workspace, session and App mode, plus an agent status strip and inline widget rendering in chat. | unverified |
 | dsh-remote-access | 0 | [KongXiangning/dsh-remote-access](https://github.com/KongXiangning/dsh-remote-access) | dsh Web GUI remote access: bind the webserver to 0.0.0.0 for LAN/remote access and inject the crypto.randomUUID polyfill for non-secure HTTP origins. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-restart-systemd | 0 | [RoyougiShiki/dsh-restart-systemd](https://github.com/RoyougiShiki/dsh-restart-systemd) | WebUI restart button (systemd) for DeepSeek Harness: a sidebar-footer restart trigger + /restart command that schedules `systemctl --user restart dsh-web`, with single-flight dedup, a loopback | 0.1.0-rc.6 (2026-08-15) |
 | dsh-show-image | 0 | [MKibera/dsh-show-image](https://github.com/MKibera/dsh-show-image) | Agent-to-user image display for the DeepSeek Harness WebUI: a show_image tool whose results render as an inline image card in the conversation (via embedded presentation data), never entering model | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
Adds one entry to `data/plugins.json`; README and `docs/` + `lists/` artifacts regenerated by `scripts/render.mjs`.

**What it is:** [dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) brings [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) (an MCP Apps engine) into dsh. Each MCP app becomes a sidebar container with its own workspace, session and App mode system prompt; an agent status strip sits under the app UI; and in an ordinary chat an `open_app` tool call renders as the running app inline. MIT.

**Install path** (spam gate, bullet 2): published npm package a profile depends on — `dsh plugin add dsh-plugin-open-app`, then a patch row in the profile's `cordis.patch.yml`. It ships `dsh.client`, not `dsh.bundle`, so the patch row is the user's, which is why `category` is `plugin` rather than `bundle`.

**Status is `unverified`, deliberately.** I inspected the manifest and the published package but did not load it against `0.1.0-rc.6` myself, so I have not claimed `verified`. `verifiedAgainst` follows the registry's prevailing value. Happy to have a maintainer flip it after a check.

Checks run locally, both exit 0:

```
validate: ok (2755 plugins, 0 candidates, 849 rejected)
render: wrote README.md + docs artifacts (2755 entries)
```

Not previously in `plugins.json`, `candidates.json`, or `rejected.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
