### PR TITLE
Add dsh-meter to the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2754 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2755 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -74,7 +74,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2647 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
+2648 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dshworks.github.io/awesome-dsh-plugins/) always hold everything.
 
@@ -450,7 +450,7 @@ Token accounting, billing, balance, quota.
 | dsh-spend | 5 | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token usage, multi-dimensional statistics, auto-detected billing plans (Code/Token) and estimated spend for the dsh web UI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-token-cost | 5 | [le-soleil-se-couche/dsh-token-cost](https://github.com/le-soleil-se-couche/dsh-token-cost) | DSH web GUI plugin: token usage (input/output), cache hit/miss and cost statistics per conversation and in aggregate, with auto-switching DeepSeek pricing schemes | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 206. **[all 206 →](lists/usage-cost.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 207. **[all 207 →](lists/usage-cost.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Observability & evidence
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48846,6 +48846,21 @@
         "ui"
       ],
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-meter",
+      "repo": "dshworks/dsh-meter",
+      "description": "DeepSeek's time-of-use meter: session cost billed at the tariff in force when each request was dispatched, the running tariff and its countdown, and a local-time tariff clock in the composer dock.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 }

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48846,6 +48846,21 @@ window.__PLUGINS__ = {
         "ui"
       ],
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-meter",
+      "repo": "dshworks/dsh-meter",
+      "description": "DeepSeek's time-of-use meter: session cost billed at the tariff in force when each request was dispatched, the running tariff and its countdown, and a local-time tariff clock in the composer dock.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48846,6 +48846,21 @@
         "ui"
       ],
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-meter",
+      "repo": "dshworks/dsh-meter",
+      "description": "DeepSeek's time-of-use meter: session cost billed at the tariff in force when each request was dispatched, the running tariff and its countdown, and a local-time tariff clock in the composer dock.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "usage",
+        "ui"
+      ]
     }
   ]
 }

--- a/lists/usage-cost.md
+++ b/lists/usage-cost.md
@@ -4,7 +4,7 @@
 
 Token accounting, billing, balance, quota.
 
-206 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+207 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -188,6 +188,7 @@ Token accounting, billing, balance, quota.
 | dsh-ibka-balance | 0 | [ibka512/dsh-ibka-balance](https://github.com/ibka512/dsh-ibka-balance) | 常驻余额监测卡片：DeepSeek API 余额实时显示，每 5 分钟自动刷新，过低变色提醒。A permanent composer-dock card showing your DeepSeek API account balance with auto-refresh and low-balance warnings. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-infra-observability | 0 | [Bryan-cmf/dsh-infra-observability](https://github.com/Bryan-cmf/dsh-infra-observability) | DSH-Plugin: structural observability layer — real tool/skill usage recording (tools/result), skill-catalog audit, and a watchdog with health/error events. No model self-reporting. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-liang-rheostat | 0 | [Codingendless/dsh-liang-rheostat](https://github.com/Codingendless/dsh-liang-rheostat/tree/HEAD/dsh-liang-rheostat-client-ui) | DeepSeek 梁表 · 滑动变阻器 — 浏览器半边:每条模型回复的回合尾部显示一行评级(梁祖/梁神/梁圣/梁子/牢梁/小难梁),数据来自会话事件里的 usage,与服务端 dsh-liang-rheostat-server 同款评分引擎 | 0.1.0-rc.6 (2026-08-15) |
+| dsh-meter | - | [dshworks/dsh-meter](https://github.com/dshworks/dsh-meter) | DeepSeek's time-of-use meter: session cost billed at the tariff in force when each request was dispatched, the running tariff and its countdown, and a local-time tariff clock in the composer dock. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-model-sync | 0 | [jiay98528-dev/dsh-model-sync](https://github.com/jiay98528-dev/dsh-model-sync) | Sync live provider model lists into DSH settings and show 5h/7d quota rings for the current session model. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-netcafe | 0 | [mario03690/dsh-netcafe](https://github.com/mario03690/dsh-netcafe) | DeepSeek Harness bundle for AI NetCafé's hosted tools. One install for the full catalogue, or pick one of four focused packs (tables, dev kit, doc flow, China facts) so you only pay the context cost | 0.1.0-rc.6 (2026-08-15) |
 | dsh-opencode-usage-fengyang | 0 | [FengYangXun123/dsh-opencode-usage](https://github.com/FengYangXun123/dsh-opencode-usage) | OpenCode Go 订阅用量监控：侧边栏底部常驻徽标（5h/周/月百分比，异常标红），点击在左侧弹出详情卡片（重置倒计时、趋势、告警、Key 配置），用量突增/超标标红提醒（防额度被他人盗刷）。 | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
`dshworks/dsh-meter` 0.1.0 — DeepSeek's time-of-use meter for the dsh Web UI.

One line in the composer dock: session cost, the tariff running right now, and
the countdown to the next change; a hover card with a local-time tariff clock,
the cache/fresh/output split, and the same tokens priced under the other tariff.

Spam gate:
- Install path: `dsh.bundle.patch` + `dsh.client` in `package.json`, one
  composition row in `cordis.patch.yml`.
- Not a template fork; 35 tests, CI green.
- Loads against `0.1.0-rc.6`: `dsh --profile web --dump-config` lists it and
  `/plugins/dsh-meter/client.js` serves. Verified live today across flat and
  peak states, a cold read after a server restart, and light/dark themes.
- Description matches what it does; no keyword stuffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)