### PR TITLE
Add yushi-xxh/dsh-homepage-skin (theme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2757 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2758 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -724,6 +724,7 @@ UI skins. The dedicated registry is [awesome-dsh-themes](https://github.com/dshw
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
 | dsh-deep-whale | 855 | [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale/tree/HEAD/maid-atelier) | Whale-girl skin series for the web UI; maid-atelier ships as a dsh.bundle package installed from a local clone (CC BY-NC-SA, non-commercial) | 0.1.0-rc.5 (2026-08-13) |
+| dsh-homepage-skin | 0 | [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) | DeepSeek Harness homepage-style background skin: WebGL fluid, dot-line grid and a digital point-cloud whale, with dark and light palettes | 0.1.0-rc.6 (2026-08-15) |
 
 ### Tools
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48895,6 +48895,22 @@
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-homepage-skin",
+      "repo": "yushi-xxh/dsh-homepage-skin",
+      "description": "DeepSeek Harness homepage-style background skin: WebGL fluid, dot-line grid and a digital point-cloud whale, with dark and light palettes",
+      "category": "theme",
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "ui"
+      ],
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "pushedAt": "2026-08-15"
     }
   ]
 }

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48895,6 +48895,22 @@ window.__PLUGINS__ = {
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-homepage-skin",
+      "repo": "yushi-xxh/dsh-homepage-skin",
+      "description": "DeepSeek Harness homepage-style background skin: WebGL fluid, dot-line grid and a digital point-cloud whale, with dark and light palettes",
+      "category": "theme",
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "ui"
+      ],
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "pushedAt": "2026-08-15"
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48895,6 +48895,22 @@
       "tags": [
         "ui"
       ]
+    },
+    {
+      "name": "dsh-homepage-skin",
+      "repo": "yushi-xxh/dsh-homepage-skin",
+      "description": "DeepSeek Harness homepage-style background skin: WebGL fluid, dot-line grid and a digital point-cloud whale, with dark and light palettes",
+      "category": "theme",
+      "added": "2026-08-15",
+      "lastVerified": "2026-08-15",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "ui"
+      ],
+      "stars": 0,
+      "starsUpdated": "2026-08-15",
+      "pushedAt": "2026-08-15"
     }
   ]
 }


### PR DESCRIPTION
Adds dsh-homepage-skin to the registry.

- theme category
- installable via `dsh plugin --profile web add github:yushi-xxh/dsh-homepage-skin` (dsh.bundle manifest + cordis.patch.yml)
- verified locally against 0.1.0-rc.6 client packages (dark/light themes, settings toggle, clean uninstall)