### PR TITLE
Point the gallery at dsh.works, and render the head from the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 [![powered by dsh](https://img.shields.io/badge/powered__by-dsh-4D6BFE?logo=deepseek)](https://github.com/deepseek-ai/deepseek-harness)
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dshworks.github.io/awesome-dsh-plugins/)
+[![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dsh.works/awesome-dsh-plugins/)
 
 A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2757 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
-**[Browse the reef](https://dshworks.github.io/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
+**[Browse the reef](https://dsh.works/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
 Most awesome lists are prose. This one is data: [`data/plugins.json`](data/plugins.json) is the source of truth, this README is rendered from it. Build on the JSON directly:
 
@@ -76,7 +76,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 2650 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-15.
 
-Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dshworks.github.io/awesome-dsh-plugins/) always hold everything.
+Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dsh.works/awesome-dsh-plugins/) always hold everything.
 
 ### Web UI
 
@@ -110,7 +110,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-qq2006 | 10 | [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 skin plugin for DSH (DeepSeek Harness): registers the 'qq2006' theme (coral-blue --dsw-alias-* token overrides), mirrors the active theme onto body[data-ds-skin], and ships the global | 0.1.0-rc.6 (2026-08-15) |
 | dsh-web-mobile | 10 | [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) | Mobile-adaptive DSH web UI: on narrow screens the sidebar rail is hidden and the directory opens as an overlay drawer, so the conversation gets the full width. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 286. **[all 286 →](lists/web-ui.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 286. **[all 286 →](lists/web-ui.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Terminals & desktop
 
@@ -144,7 +144,7 @@ TUIs, desktop shells, headless runners.
 | deepseek-harness-desktop-bailang1 | 5 | [bailang1218/deepseek-harness-desktop](https://github.com/bailang1218/deepseek-harness-desktop) | Community-maintained self-contained Tauri desktop distribution for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-desktop-ethanwea | 5 | [ethanweave/dsh-desktop](https://github.com/ethanweave/dsh-desktop/tree/HEAD/runtime) | DeepSeek Harness 桌面应用（类 Codex）：原生窗口 + 系统托盘 | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 119. **[all 119 →](lists/terminals-desktop.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 119. **[all 119 →](lists/terminals-desktop.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Tools & capabilities
 
@@ -178,7 +178,7 @@ New things the model can do: search, browser, files, databases, devices, media.
 | dsh-web-review | 15 | [CanglongCl/dsh-web-review](https://github.com/CanglongCl/dsh-web-review/tree/HEAD/packages/dsh-web-review) | DSH web review plugin: page preview, element annotation, visual adjustments, and AI-driven workspace source edits | 0.1.0-rc.6 (2026-08-15) |
 | dsh-computer-use-zrui | 13 | [ZRui-C/dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) | Text-first browser and background macOS control for DeepSeek Harness, targeting the right process and window without grabbing the pointer. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 514. **[all 514 →](lists/tools-capabilities.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 514. **[all 514 →](lists/tools-capabilities.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Vision
 
@@ -212,7 +212,7 @@ Image understanding for text-only models.
 | deepseek-harness-desktop-kevph202 | 3 | [KevPH2026/deepseek-harness-desktop](https://github.com/KevPH2026/deepseek-harness-desktop) | A native macOS desktop experience for DeepSeek Harness — multimodal generation, community plugin discovery, safe updates, and bilingual docs. | 0.1.0-rc.6 (2026-08-15) |
 | DeepSeek-Harness-linux- | 3 | [MoneShadow/DeepSeek-Harness-linux-](https://github.com/MoneShadow/DeepSeek-Harness-linux-/tree/HEAD/plugins/dsh-plugin-vision) | Vision assist for DeepSeek Harness: lets the main model see images through an OpenAI-compatible vision API | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 146. **[all 146 →](lists/vision.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 146. **[all 146 →](lists/vision.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Agents & orchestration
 
@@ -246,7 +246,7 @@ Subagents, workflows, cross-session coordination.
 | cathead-coding | 5 | [catyans/cathead-coding](https://github.com/catyans/cathead-coding) | A delightful open-source coding agent CLI powered by DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 | deepseek-acp | 5 | [xintaofei/deepseek-acp](https://github.com/xintaofei/deepseek-acp) | Editor-facing Agent Client Protocol adapter for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 217. **[all 217 →](lists/agents-orchestration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 217. **[all 217 →](lists/agents-orchestration.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Memory & sessions
 
@@ -280,7 +280,7 @@ Memory systems, context management, session search/rewind/export.
 | dsh-evolve | 5 | [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) | 自进化插件：agent 在 session 内随对话按需给自己长出/剪掉能力 —— evolve_add 把 cordis 插件源码落盘并热挂载（下一 step 工具即可见），evolve_remove 可逆卸载，重启自动恢复 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-recall-plugin | 5 | [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) · [npm](https://www.npmjs.com/package/dsh-recall-plugin) | DSH 消息撤回插件：在用户消息气泡旁加「撤回」按钮，把项目文件（独立影子 git 仓库快照）与对话历史（官方 fork）一并回退到该消息发送之前。 | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 282. **[all 282 →](lists/memory-sessions.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 282. **[all 282 →](lists/memory-sessions.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Models & providers
 
@@ -314,7 +314,7 @@ Providers, routing, fallbacks, subscription adapters.
 | dsh-subscription-auth | 4 | [Khellendros97/dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) | 订阅会员 OAuth 登录（ChatGPT 等）：配置中心「订阅服务」页登录/注销，自动发现订阅模型列表，按登录状态注册提供商，支持思考强度选择 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-attachment-formats | 3 | [linkingoscar/dsh-attachment-formats](https://github.com/linkingoscar/dsh-attachment-formats) · [npm](https://www.npmjs.com/package/dsh-attachment-formats) | Codex-style attachment format expansion for the DeepSeek Harness Web GUI: PDF text-layer extraction (pymupdf4llm / pdfjs), Office text extraction, long-document spill + index cards, scanned-PDF OCR (t | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 140. **[all 140 →](lists/models-providers.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 140. **[all 140 →](lists/models-providers.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Interop & migration
 
@@ -348,7 +348,7 @@ Bridges to and from Claude Code, Codex, and other harnesses.
 | dsh-plugin-session-import | 4 | [huguangyu666/dsh-plugin-session-import](https://github.com/huguangyu666/dsh-plugin-session-import) · [npm](https://www.npmjs.com/package/dsh-plugin-session-import) | Import claude-code, Codex, reasonix, and zcode chat histories into dsh sessions with workspace binding. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-vscode | 4 | [MJ-Chang/dsh-vscode](https://github.com/MJ-Chang/dsh-vscode) | Run DeepSeek Harness inside VS Code: chat with the agent and edit your project, like Claude Code / Codex / Copilot. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 95. **[all 95 →](lists/interop-migration.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 95. **[all 95 →](lists/interop-migration.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Channels & remote
 
@@ -382,7 +382,7 @@ IM bridges and remote control: Feishu, Telegram, WeCom, DingTalk.
 | dsh-lark-channel | 3 | [sliverp/DeepSeek-harness-lark](https://github.com/sliverp/DeepSeek-harness-lark) | Feishu and Lark text, image, and file channel bridge for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 | dsh-onebot | 3 | [Hoshino-Yumetsuki/dsh-onebot](https://github.com/Hoshino-Yumetsuki/dsh-onebot) · [npm](https://www.npmjs.com/package/dsh-onebot) | OneBot v11 HTTP and WebSocket adapter for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 79. **[all 79 →](lists/channels-remote.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 79. **[all 79 →](lists/channels-remote.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Notifications
 
@@ -416,7 +416,7 @@ Alerting the human: desktop, sound, even a phone call.
 | dsh-notify | 1 | [TerricSH/dsh-notify](https://github.com/TerricSH/dsh-notify) · [npm](https://www.npmjs.com/package/@terricsh/dsh-notify) | Desktop notifications for DeepSeek Harness approval, completion, and error events with click-to-open deep links. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-notify-bark | 1 | [pc439527/dsh-notify-bark](https://github.com/pc439527/dsh-notify-bark) | Bark 推送通知插件：DSH Host 端监听回合结束 / 等待回答 / 等待授权等事件，通过 Bark Server 推送到 iPhone。设置页经专用 RPC 读写 Host 配置（Bark 地址脱敏，不落地到浏览器）。 | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 44. **[all 44 →](lists/notifications.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 44. **[all 44 →](lists/notifications.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Usage & cost
 
@@ -450,7 +450,7 @@ Token accounting, billing, balance, quota.
 | dsh-spend | 5 | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token usage, multi-dimensional statistics, auto-detected billing plans (Code/Token) and estimated spend for the dsh web UI | 0.1.0-rc.6 (2026-08-15) |
 | dsh-token-cost | 5 | [le-soleil-se-couche/dsh-token-cost](https://github.com/le-soleil-se-couche/dsh-token-cost) | DSH web GUI plugin: token usage (input/output), cache hit/miss and cost statistics per conversation and in aggregate, with auto-switching DeepSeek pricing schemes | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 207. **[all 207 →](lists/usage-cost.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 207. **[all 207 →](lists/usage-cost.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Observability & evidence
 
@@ -484,7 +484,7 @@ Diagnostics, logs, audits, content-addressed proofs.
 | dsh-release-proof | 3 | [dongsheng123132/dsh-release-proof](https://github.com/dongsheng123132/dsh-release-proof) | Reproducible multi-source release evidence for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 | dsh-telemetry-redactor | 3 | [030611/dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) | Export-copy redaction for DeepSeek Harness session telemetry | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 66. **[all 66 →](lists/observability-evidence.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 66. **[all 66 →](lists/observability-evidence.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Safety & approvals
 
@@ -518,7 +518,7 @@ Permission tiers, gates, redaction, protection.
 | dsh-promptwall | 3 | [Chhlafiu4312/promptwall](https://github.com/Chhlafiu4312/promptwall) · [npm](https://www.npmjs.com/package/dsh-promptwall) | Local prompt-injection and secret-exfiltration firewall for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-safe-delete | 3 | [Qintsg/dsh-safe-delete](https://github.com/Qintsg/dsh-safe-delete) | Safe delete plugin for DeepSeek Harness (DSH): move files to trash / staging area instead of permanent removal, with restore and purge support. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 93. **[all 93 →](lists/safety-approvals.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 93. **[all 93 →](lists/safety-approvals.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Plugin managers & stores
 
@@ -552,7 +552,7 @@ In-UI stores, installers, skill managers.
 | dsh-skills | 6 | [CocoSgt/dsh-skills](https://github.com/CocoSgt/dsh-skills) · [npm](https://www.npmjs.com/package/dsh-skills) | Global skill hub for dsh: aggregates Claude Code, project, and .skill sources in Settings. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-extension-hub | 5 | [Relistencode/dsh-extension-hub](https://github.com/Relistencode/dsh-extension-hub) · [npm](https://www.npmjs.com/package/dsh-extension-hub) | Manage DeepSeek Harness skills and MCP servers from the web settings page, with import from Claude and Codex. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 126. **[all 126 →](lists/plugin-managers-stores.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 126. **[all 126 →](lists/plugin-managers-stores.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Developer tools
 
@@ -586,7 +586,7 @@ Building, testing, and publishing plugins.
 | dsh-plugin-auditor | 2 | [HYY-King/dsh-plugin-auditor](https://github.com/HYY-King/dsh-plugin-auditor) · [npm](https://www.npmjs.com/package/dsh-plugin-auditor) | DSH 插件审核器：在新插件加入 profile 前扫描组合兼容性——重复工具注册、entry id 冲突、peer 版本不匹配、记忆插件唯一性、渠道插件凭据，输出风险报告，预防启动崩溃。 | 0.1.0-rc.6 (2026-08-14) |
 | dsh-plugin-reload | 2 | [reina4xa/dsh-plugin-reload](https://github.com/reina4xa/dsh-plugin-reload) · [npm](https://www.npmjs.com/package/dsh-plugin-reload) | A DeepSeek Harness plugin: model-facing reload_plugin tool that restarts one Cordis Loader entry (by entry id, module name, or MCP serverName) without touching sibling entries — respawns mcp-client... | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 45. **[all 45 →](lists/developer-tools.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 45. **[all 45 →](lists/developer-tools.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Knowledge & research
 
@@ -620,7 +620,7 @@ Research workbenches, RAG, learning modes.
 | dsh-plugin-knowledge-graph | 3 | [Luke-Yong/dsh-plugin-knowledge-graph](https://github.com/Luke-Yong/dsh-plugin-knowledge-graph) | DeepSeek Harness plugin: a read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL). | 0.1.0-rc.6 (2026-08-15) |
 | dsh-research-notes | 3 | [fff122/dsh-research-notes](https://github.com/fff122/dsh-research-notes) | A local research notes plugin for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 87. **[all 87 →](lists/knowledge-research.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 87. **[all 87 →](lists/knowledge-research.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Fun
 
@@ -654,7 +654,7 @@ Games, pets, memes, ambience. The reef has coral.
 | 7d7d | 4 | [omdsh-dev/7d7d](https://github.com/omdsh-dev/7d7d) | 7d7d —— 7k7k 风格的 DSH 游戏门户：在 Web UI 内生成、同步并游玩 HTML5 与自托管 Ruffle Flash 小游戏。 | 0.1.0-rc.6 (2026-08-14) |
 | dsh-deepseek-girl-pet | 4 | [f0909172434/dsh-deepseek-girl-pet](https://github.com/f0909172434/dsh-deepseek-girl-pet) | Animated deepseek girl desktop pet overlay for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 104. **[all 104 →](lists/fun.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 104. **[all 104 →](lists/fun.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Bundles
 
@@ -688,7 +688,7 @@ npm packages with a `dsh.bundle` manifest: composition layers a profile boots fr
 | dsh-deepseek-vision | 3 | [Argonaut790/dsh-deepseek-vision](https://github.com/Argonaut790/dsh-deepseek-vision) · [npm](https://www.npmjs.com/package/dsh-deepseek-vision) | Image understanding, OCR, and persistent visual evidence for text-only DeepSeek Harness models. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-docker | 3 | [STARDUSTLC666/dsh-docker](https://github.com/STARDUSTLC666/dsh-docker) · [npm](https://www.npmjs.com/package/dsh-docker) | Docker container tools for DeepSeek Harness: ps, logs, inspect, exec, and manage via the official subprocess service. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 83. **[all 83 →](lists/bundles.md)** · [gallery](https://dshworks.github.io/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 83. **[all 83 →](lists/bundles.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Skills
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>awesome-dsh-plugins — the reef</title>
-  <meta name="description" content="406+ DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <!-- render:meta -->
+  <meta name="description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <link rel="canonical" href="https://dsh.works/awesome-dsh-plugins/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="dshworks">
+  <meta property="og:title" content="awesome-dsh-plugins — the reef">
+  <meta property="og:description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta property="og:url" content="https://dsh.works/awesome-dsh-plugins/">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="awesome-dsh-plugins — the reef">
+  <meta name="twitter:description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <!-- /render:meta -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='%23071824'/%3E%3Cpath d='M8 22c2-6 6-9 12-9-2 3-2 5 0 8-4 2-8 2-12 1z' fill='%23ff7a59'/%3E%3Ccircle cx='22' cy='12' r='2' fill='%237ef0ff'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -64,7 +75,7 @@
   <footer class="foot">
     <p>Not affiliated with DeepSeek. <span aria-hidden="true" id="heart-anchor">❤️</span> for everyone growing the reef anyway.</p>
     <p>
-      Sisters: <a href="https://dshworks.github.io/awesome-dsh-themes/">awesome-dsh-themes</a>
+      Sisters: <a href="https://dsh.works/awesome-dsh-themes/">awesome-dsh-themes</a>
       · <a href="https://github.com/dshworks/howto-dsh">howto-dsh</a>
       · Source: <a href="https://github.com/dshworks/awesome-dsh-plugins">awesome-dsh-plugins</a>
     </p>

--- a/lists/agents-orchestration.md
+++ b/lists/agents-orchestration.md
@@ -4,7 +4,7 @@
 
 Subagents, workflows, cross-session coordination.
 
-217 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+217 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/bundles.md
+++ b/lists/bundles.md
@@ -4,7 +4,7 @@
 
 npm packages with a `dsh.bundle` manifest: composition layers a profile boots from.
 
-83 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+83 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/channels-remote.md
+++ b/lists/channels-remote.md
@@ -4,7 +4,7 @@
 
 IM bridges and remote control: Feishu, Telegram, WeCom, DingTalk.
 
-79 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+79 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/developer-tools.md
+++ b/lists/developer-tools.md
@@ -4,7 +4,7 @@
 
 Building, testing, and publishing plugins.
 
-45 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+45 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/fun.md
+++ b/lists/fun.md
@@ -4,7 +4,7 @@
 
 Games, pets, memes, ambience. The reef has coral.
 
-104 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+104 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/interop-migration.md
+++ b/lists/interop-migration.md
@@ -4,7 +4,7 @@
 
 Bridges to and from Claude Code, Codex, and other harnesses.
 
-95 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+95 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/knowledge-research.md
+++ b/lists/knowledge-research.md
@@ -4,7 +4,7 @@
 
 Research workbenches, RAG, learning modes.
 
-87 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+87 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/memory-sessions.md
+++ b/lists/memory-sessions.md
@@ -4,7 +4,7 @@
 
 Memory systems, context management, session search/rewind/export.
 
-282 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+282 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/models-providers.md
+++ b/lists/models-providers.md
@@ -4,7 +4,7 @@
 
 Providers, routing, fallbacks, subscription adapters.
 
-140 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+140 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/notifications.md
+++ b/lists/notifications.md
@@ -4,7 +4,7 @@
 
 Alerting the human: desktop, sound, even a phone call.
 
-44 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+44 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/observability-evidence.md
+++ b/lists/observability-evidence.md
@@ -4,7 +4,7 @@
 
 Diagnostics, logs, audits, content-addressed proofs.
 
-66 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+66 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/plugin-managers-stores.md
+++ b/lists/plugin-managers-stores.md
@@ -4,7 +4,7 @@
 
 In-UI stores, installers, skill managers.
 
-126 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+126 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/safety-approvals.md
+++ b/lists/safety-approvals.md
@@ -4,7 +4,7 @@
 
 Permission tiers, gates, redaction, protection.
 
-93 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+93 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/terminals-desktop.md
+++ b/lists/terminals-desktop.md
@@ -4,7 +4,7 @@
 
 TUIs, desktop shells, headless runners.
 
-119 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+119 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/tools-capabilities.md
+++ b/lists/tools-capabilities.md
@@ -4,7 +4,7 @@
 
 New things the model can do: search, browser, files, databases, devices, media.
 
-514 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+514 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/usage-cost.md
+++ b/lists/usage-cost.md
@@ -4,7 +4,7 @@
 
 Token accounting, billing, balance, quota.
 
-207 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+207 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/vision.md
+++ b/lists/vision.md
@@ -4,7 +4,7 @@
 
 Image understanding for text-only models.
 
-146 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+146 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/lists/web-ui.md
+++ b/lists/web-ui.md
@@ -4,7 +4,7 @@
 
 Panels, composer upgrades, navigation, layout, mobile.
 
-286 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dshworks.github.io/awesome-dsh-plugins/).
+286 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "Spam-filtered open-data registry of DeepSeek Harness (dsh) plugins, bundles, skills, and themes",
   "registry": {
     "org": "dshworks",
-    "repo": "awesome-dsh-plugins"
+    "repo": "awesome-dsh-plugins",
+    "site": "https://dsh.works"
   },
   "scripts": {
     "validate": "node scripts/validate.mjs",

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -20,7 +20,11 @@ const data = read("data/plugins.json");
 
 const HARNESS = "deepseek-ai/deepseek-harness";
 const BADGE = "https://img.shields.io/badge/powered__by-dsh-4D6BFE?logo=deepseek";
-const GALLERY = `https://${cfg.org}.github.io/${cfg.repo}/`;
+// The org's own domain when it has one; GitHub's default host otherwise. Pages
+// serves the project sites under both, but only one of them is the brand, and
+// a canonical pointing at the other is a canonical pointing at a redirect.
+const SITE = cfg.site ?? `https://${cfg.org}.github.io`;
+const GALLERY = `${SITE}/${cfg.repo}/`;
 
 const CATEGORIES = [
   ["bundle", "Bundles", "npm packages with a `dsh.bundle` manifest: composition layers a profile boots from."],
@@ -245,9 +249,40 @@ MIT. Not affiliated with DeepSeek; the harness README calls itself "an idea, an 
 
 mkdirSync(join(ROOT, "docs"), { recursive: true });
 mkdirSync(join(ROOT, "lists"), { recursive: true });
+// The hero count is filled in by reef.js at runtime, but a crawler and a chat
+// unfurl only ever see the served HTML — so the count in the head has to be
+// rendered from the data too, or it freezes at whatever it said the day it was
+// typed. Everything between the markers is generated; the rest of the page is
+// hand-written.
+const escAttr = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+const PAGE_TITLE = "awesome-dsh-plugins — the reef";
+const PAGE_DESC = `${data.plugins.length} DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.`;
+const headMeta = [
+  `<meta name="description" content="${escAttr(PAGE_DESC)}">`,
+  `<link rel="canonical" href="${GALLERY}">`,
+  `<meta property="og:type" content="website">`,
+  `<meta property="og:site_name" content="${escAttr(cfg.org)}">`,
+  `<meta property="og:title" content="${escAttr(PAGE_TITLE)}">`,
+  `<meta property="og:description" content="${escAttr(PAGE_DESC)}">`,
+  `<meta property="og:url" content="${GALLERY}">`,
+  `<meta name="twitter:card" content="summary">`,
+  `<meta name="twitter:title" content="${escAttr(PAGE_TITLE)}">`,
+  `<meta name="twitter:description" content="${escAttr(PAGE_DESC)}">`,
+].map((line) => `  ${line}`).join("\n");
+
+const INDEX_REL = "docs/index.html";
+const indexSrc = readFileSync(join(ROOT, INDEX_REL), "utf8");
+const MARKERS = /<!-- render:meta -->[\s\S]*?<!-- \/render:meta -->/;
+if (!MARKERS.test(indexSrc)) {
+  console.error(`render: ${INDEX_REL} is missing the <!-- render:meta --> markers; head cannot be rendered`);
+  process.exit(1);
+}
+const indexBody = indexSrc.replace(MARKERS, `<!-- render:meta -->\n${headMeta}\n  <!-- /render:meta -->`);
+
 const artifacts = [
   { rel: "README.md", body: readme },
   ...lists,
+  { rel: INDEX_REL, body: indexBody },
   { rel: "docs/plugins.json", body: `${JSON.stringify(data, null, 2)}\n` },
   { rel: "docs/plugins-embed.js", body: `window.__PLUGINS__ = ${JSON.stringify(data, null, 2)};\n` },
 ];


### PR DESCRIPTION
`dsh.works` went live today. Every generated link still named `dshworks.github.io`, which now 301s to it — the pages worked, the brand didn't show.

- `GALLERY` now reads a `site` field from `package.json` "registry", next to `org` and `repo`, so the host stays defined in exactly one place. README badge + prose and all 17 `lists/` footers follow on re-render. Falls back to `<org>.github.io` if `site` is absent.
- `docs/index.html` gains a rendered `<!-- render:meta -->` block: description, `canonical`, OpenGraph, Twitter card. Previously the page had **no canonical and no share tags at all** — every link shared anywhere unfurled as a naked URL.
- That head also hardcoded `"406+"` plugins against a registry of **2757**. `#hero-count` is filled by `reef.js` at runtime, but crawlers and chat unfurls only ever see the served HTML. It renders from the data now and `--check` keeps it in sync.
- The hand-written sister link in the footer repointed too.

No entry data touched. `validate` ok (2757), `render --check` in sync.

Follow-up not in here: there is no OG image, so cards render as `summary` (text only). A 1200x630 share image would upgrade both galleries to `summary_large_image`.