### PR TITLE
registry: add dsh-otel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dsh.works/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2757 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2758 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dsh.works/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -75,7 +75,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2650 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-16.
+2651 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-16.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dsh.works/awesome-dsh-plugins/) always hold everything.
 
@@ -485,7 +485,7 @@ Diagnostics, logs, audits, content-addressed proofs.
 | dsh-recovery-proof | 3 | [dongsheng123132/dsh-recovery-proof](https://github.com/dongsheng123132/dsh-recovery-proof) | Read-only recovery drill evidence for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 | dsh-release-proof | 3 | [dongsheng123132/dsh-release-proof](https://github.com/dongsheng123132/dsh-release-proof) | Reproducible multi-source release evidence for DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 66. **[all 66 →](lists/observability-evidence.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 67. **[all 67 →](lists/observability-evidence.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Safety & approvals
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48901,6 +48901,21 @@
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-otel",
+      "repo": "krimvp/dsh-otel",
+      "npm": "dsh-otel",
+      "description": "OpenTelemetry traces and metrics for DeepSeek Harness: turn, step, model-call, and tool-call spans under the GenAI semantic conventions, exported over OTLP to any backend.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,16 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>awesome-dsh-plugins — the reef</title>
   <!-- render:meta -->
-  <meta name="description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <link rel="canonical" href="https://dsh.works/awesome-dsh-plugins/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="dshworks">
   <meta property="og:title" content="awesome-dsh-plugins — the reef">
-  <meta property="og:description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta property="og:description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <meta property="og:url" content="https://dsh.works/awesome-dsh-plugins/">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="awesome-dsh-plugins — the reef">
-  <meta name="twitter:description" content="2757 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="twitter:description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <!-- /render:meta -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='%23071824'/%3E%3Cpath d='M8 22c2-6 6-9 12-9-2 3-2 5 0 8-4 2-8 2-12 1z' fill='%23ff7a59'/%3E%3Ccircle cx='22' cy='12' r='2' fill='%237ef0ff'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48901,6 +48901,21 @@ window.__PLUGINS__ = {
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-otel",
+      "repo": "krimvp/dsh-otel",
+      "npm": "dsh-otel",
+      "description": "OpenTelemetry traces and metrics for DeepSeek Harness: turn, step, model-call, and tool-call spans under the GenAI semantic conventions, exported over OTLP to any backend.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "observability"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48901,6 +48901,21 @@
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-15"
+    },
+    {
+      "name": "dsh-otel",
+      "repo": "krimvp/dsh-otel",
+      "npm": "dsh-otel",
+      "description": "OpenTelemetry traces and metrics for DeepSeek Harness: turn, step, model-call, and tool-call spans under the GenAI semantic conventions, exported over OTLP to any backend.",
+      "category": "plugin",
+      "official": false,
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/stats.json
+++ b/docs/stats.json
@@ -1,10 +1,10 @@
 {
   "updated": "2026-08-16",
-  "plugins": 2757,
-  "npm": 580,
+  "plugins": 2758,
+  "npm": 581,
   "categories": {
     "bundle": 83,
-    "plugin": 2650,
+    "plugin": 2651,
     "skill": 20,
     "theme": 1,
     "tool": 3

--- a/lists/observability-evidence.md
+++ b/lists/observability-evidence.md
@@ -4,7 +4,7 @@
 
 Diagnostics, logs, audits, content-addressed proofs.
 
-66 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
+67 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -69,6 +69,7 @@ Diagnostics, logs, audits, content-addressed proofs.
 | dsh-feedback | 0 | [TT432/dsh-feedback](https://github.com/TT432/dsh-feedback) | Feedback log for DeepSeek Harness — lightweight add/list/delete of process feedback, persisted to {cwd}/work/feedback.json, plus a runtime skill describing the mechanism. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-growth | 0 | [winyh/dsh-growth](https://github.com/winyh/dsh-growth) | DeepSeek Harness tools for evidence-backed user growth, customer acquisition, AARRR funnels, retention, unit economics and MRR. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-jwt | 0 | [ZhijiangTang/dsh-jwt](https://github.com/ZhijiangTang/dsh-jwt) | DSH plugin: decode and inspect JWT tokens (debug only, no signature verification). | 0.1.0-rc.6 (2026-08-15) |
+| dsh-otel | - | [krimvp/dsh-otel](https://github.com/krimvp/dsh-otel) · [npm](https://www.npmjs.com/package/dsh-otel) | OpenTelemetry traces and metrics for DeepSeek Harness: turn, step, model-call, and tool-call spans under the GenAI semantic conventions, exported over OTLP to any backend. | 0.1.0-rc.6 (2026-08-16) |
 | dsh-plugin-warroom-garak | 0 | [lukethecat/dsh-plugin-warroom-garak](https://github.com/lukethecat/dsh-plugin-warroom-garak) | War-room garak baseline scan tool for DeepSeek Harness — runs an authorized garak probe sweep against a target LLM endpoint and returns auditable findings + an evidence report. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-scout-maxhouin | 0 | [MaxHou-infinity/dsh-scout](https://github.com/MaxHou-infinity/dsh-scout) | Evidence-driven company and job intelligence plugin for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-tool-backtest | 0 | [dmsobtl/dsh-tool-backtest](https://github.com/dmsobtl/dsh-tool-backtest) | DSH plugin: strategy backtesting engine — define strategies in natural language, run against historical data, get performance metrics. | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
OpenTelemetry traces and metrics for the dsh agent loop. Published as dsh-otel on npm. validate.mjs and render.mjs both run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln1BPGMsJ98tJ7nmgjss2R