### PR TITLE
Add dsh-airlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dsh.works/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2759 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2760 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dsh.works/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -75,7 +75,7 @@ Hand-curated, sparing, and revisited as the ecosystem moves; the ⭐ mark in the
 
 ## Plugins by area
 
-2651 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-16.
+2652 Cordis plugins activated through patch rows in a bundle or profile, grouped by what they do. Data updated 2026-08-16.
 
 Each area shows its 25 most-starred entries and links to the complete list in [`lists/`](lists). GitHub stops rendering a markdown file partway through once it passes about half a megabyte — silently, mid-row — so the full tables live in files small enough to survive that. Nothing is dropped: [`data/plugins.json`](data/plugins.json) and the [gallery](https://dsh.works/awesome-dsh-plugins/) always hold everything.
 
@@ -519,7 +519,7 @@ Permission tiers, gates, redaction, protection.
 | dsh-tool-git-lxj808624 | 4 | [lxj808624/dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) | Structured, safe Git tool family for DeepSeek Harness: status/diff/log/branch/stage/commit/stash/show/fetch/pull/remote/checkout with a destructive-command guard. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-agentfuse | 3 | [MkaliezZ/dsh-agentfuse-plugin](https://github.com/MkaliezZ/dsh-agentfuse-plugin) · [npm](https://www.npmjs.com/package/@deepseek-ai/dsh-agentfuse) | AgentFuse fail-closed pre-dispatch tool gate for DeepSeek Harness with durable allow/block decision evidence. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 93. **[all 93 →](lists/safety-approvals.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 94. **[all 94 →](lists/safety-approvals.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Plugin managers & stores
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48938,6 +48938,21 @@
       "stars": 1,
       "starsUpdated": "2026-08-17",
       "pushedAt": "2026-08-17"
+    },
+    {
+      "name": "dsh-airlock",
+      "repo": "krimvp/dsh-airlock",
+      "npm": "dsh-airlock",
+      "description": "Labels context by where it came from and denies capabilities over those labels, so a denied call cannot be reformulated into an allowed one.",
+      "category": "plugin",
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "safety",
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,16 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>awesome-dsh-plugins — the reef</title>
   <!-- render:meta -->
-  <meta name="description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="description" content="2760 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <link rel="canonical" href="https://dsh.works/awesome-dsh-plugins/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="dshworks">
   <meta property="og:title" content="awesome-dsh-plugins — the reef">
-  <meta property="og:description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta property="og:description" content="2760 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <meta property="og:url" content="https://dsh.works/awesome-dsh-plugins/">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="awesome-dsh-plugins — the reef">
-  <meta name="twitter:description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="twitter:description" content="2760 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <!-- /render:meta -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='%23071824'/%3E%3Cpath d='M8 22c2-6 6-9 12-9-2 3-2 5 0 8-4 2-8 2-12 1z' fill='%23ff7a59'/%3E%3Ccircle cx='22' cy='12' r='2' fill='%237ef0ff'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48938,6 +48938,21 @@ window.__PLUGINS__ = {
       "stars": 1,
       "starsUpdated": "2026-08-17",
       "pushedAt": "2026-08-17"
+    },
+    {
+      "name": "dsh-airlock",
+      "repo": "krimvp/dsh-airlock",
+      "npm": "dsh-airlock",
+      "description": "Labels context by where it came from and denies capabilities over those labels, so a denied call cannot be reformulated into an allowed one.",
+      "category": "plugin",
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "safety",
+        "observability"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48938,6 +48938,21 @@
       "stars": 1,
       "starsUpdated": "2026-08-17",
       "pushedAt": "2026-08-17"
+    },
+    {
+      "name": "dsh-airlock",
+      "repo": "krimvp/dsh-airlock",
+      "npm": "dsh-airlock",
+      "description": "Labels context by where it came from and denies capabilities over those labels, so a denied call cannot be reformulated into an allowed one.",
+      "category": "plugin",
+      "added": "2026-08-16",
+      "lastVerified": "2026-08-16",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "safety",
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/stats.json
+++ b/docs/stats.json
@@ -1,10 +1,10 @@
 {
   "updated": "2026-08-16",
-  "plugins": 2759,
-  "npm": 582,
+  "plugins": 2760,
+  "npm": 583,
   "categories": {
     "bundle": 84,
-    "plugin": 2651,
+    "plugin": 2652,
     "skill": 20,
     "theme": 1,
     "tool": 3

--- a/lists/safety-approvals.md
+++ b/lists/safety-approvals.md
@@ -4,7 +4,7 @@
 
 Permission tiers, gates, redaction, protection.
 
-93 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
+94 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -76,6 +76,7 @@ Permission tiers, gates, redaction, protection.
 | dsh-self-evolving | 1 | [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving/tree/HEAD/packages/candidate-baseline) | Stable baseline parent candidate. Namespace-form DSH bundle; loaded through the real Cordis Loader in Gate 0. Not a profile, not a generated candidate. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-todo-freshness-guard | 1 | [lamost423/dsh-todo-freshness-guard](https://github.com/lamost423/dsh-todo-freshness-guard) | Remind and block stale tool work until todo_write is reconciled in DeepSeek Harness | 0.1.0-rc.6 (2026-08-14) |
 | dsh-tool-approval | 1 | [ilharp/dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) | Manual approval for Deepseek Harness (aka "Manual Mode"/"Ask Mode") | 0.1.0-rc.6 (2026-08-15) |
+| dsh-airlock | - | [krimvp/dsh-airlock](https://github.com/krimvp/dsh-airlock) · [npm](https://www.npmjs.com/package/dsh-airlock) | Labels context by where it came from and denies capabilities over those labels, so a denied call cannot be reformulated into an allowed one. | 0.1.0-rc.6 (2026-08-16) |
 | dsh-approval-flow-poc | 0 | [lasoloryan/dsh-approval-flow-poc](https://github.com/lasoloryan/dsh-approval-flow-poc) | A fail-closed, auditable approval policy plugin for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-approval-gate | 0 | [moon09300731/dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) | DeepSeek Harness 自动审批门控：Flash 模型预判写入/命令是否不可回补，安全自动批准、危险转人工（fail-safe） | 0.1.0-rc.6 (2026-08-15) |
 | dsh-arbitrary-host | 0 | [FairyScript/dsh-arbitrary-host](https://github.com/FairyScript/dsh-arbitrary-host/tree/HEAD/plugin) | Non-invasive dsh web bundle layer: accepts an arbitrary --host, gates the app behind secure contexts, auto-trusts a concrete LAN-IP bind, and makes the connection privileged-method gate configurable. | 0.1.0-rc.6 (2026-08-15) |


### PR DESCRIPTION
Adds **dsh-airlock** — labels context by where it came from and denies capabilities over those labels, so a denied call cannot be reformulated into an allowed one.

- Repo: https://github.com/krimvp/dsh-airlock (carries the `dsh-plugin` topic)
- npm: https://www.npmjs.com/package/dsh-airlock (`dsh-airlock@0.1.0`, published today)
- `status: verified` / `verifiedAgainst: 0.1.0-rc.6` — `e2e/verify.sh` in the plugin repo ran against rc.6 with a control arm
- `node scripts/validate.mjs`: ok (2759 plugins) · `node scripts/render.mjs`: README, lists/ and docs/ artifacts regenerated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgDNozG1SYFdRARwM7SwRB