### PR TITLE
Rename dsh-smooth-stream entry to dsh-plugin-smooth-stream, add npm, retag ui, re-verify against 0.1.0-rc.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-mobile | 14 | [lehhair/dsh-mobile](https://github.com/lehhair/dsh-mobile) | Narrow-screen pager: the stock three-column frame becomes a swipeable sidebar\|chat pager with safe-area insets. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-gui-customization | 13 | [LAN-TINA-WS/dsh-gui-customization](https://github.com/LAN-TINA-WS/dsh-gui-customization/tree/HEAD/packages/dsh-gui-customization) | DSH theme plugin for the DeepSeek Harness Web UI: Nous Blue palette, ambient glow, dynamic image/video backgrounds. DSH 界面设定插件：配色 / 氛围光 / 动态背景（中英双语） | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 286. **[all 286 →](lists/web-ui.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 287. **[all 287 →](lists/web-ui.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Terminals & desktop
 
@@ -179,7 +179,7 @@ New things the model can do: search, browser, files, databases, devices, media.
 | billion-context-dsh | 17 | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | Active Context Pruning (ACP) for the DeepSeek Harness — model-driven context management as a CompactionEngine backend. | 0.1.0-rc.6 (2026-08-15) |
 | quantum-practices | 17 | [unitarylab/quantum-practices](https://github.com/unitarylab/quantum-practices) | Quantum Algorithms Best Practices tool bundle for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 
-<sub>Showing the 25 most-starred of 514. **[all 514 →](lists/tools-capabilities.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 513. **[all 513 →](lists/tools-capabilities.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Vision
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -21913,21 +21913,22 @@
       "pushedAt": "2026-08-13"
     },
     {
-      "name": "dsh-smooth-stream",
-      "repo": "SpookySandwich/dsh-smooth-stream",
-      "description": "DeepSeek Harness plugin: reveal assistant replies in calm fading chunks instead of token-by-token twitch.",
+      "name": "dsh-plugin-smooth-stream",
+      "repo": "SpookySandwich/dsh-plugin-smooth-stream",
+      "description": "Reveals assistant replies in fading paragraph batches instead of token-by-token; smooth scroll-follow while streaming, live summary line on thinking blocks, respects prefers-reduced-motion.",
       "category": "plugin",
       "official": false,
       "added": "2026-08-15",
-      "lastVerified": "2026-08-15",
+      "lastVerified": "2026-08-16",
       "verifiedAgainst": "0.1.0-rc.6",
       "status": "verified",
       "stars": 8,
       "starsUpdated": "2026-08-16",
       "tags": [
-        "capabilities"
+        "ui"
       ],
-      "pushedAt": "2026-08-16"
+      "pushedAt": "2026-08-16",
+      "npm": "dsh-plugin-smooth-stream"
     },
     {
       "name": "deepseek-harness-desktop-starsqvq",

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -21913,21 +21913,22 @@ window.__PLUGINS__ = {
       "pushedAt": "2026-08-13"
     },
     {
-      "name": "dsh-smooth-stream",
-      "repo": "SpookySandwich/dsh-smooth-stream",
-      "description": "DeepSeek Harness plugin: reveal assistant replies in calm fading chunks instead of token-by-token twitch.",
+      "name": "dsh-plugin-smooth-stream",
+      "repo": "SpookySandwich/dsh-plugin-smooth-stream",
+      "description": "Reveals assistant replies in fading paragraph batches instead of token-by-token; smooth scroll-follow while streaming, live summary line on thinking blocks, respects prefers-reduced-motion.",
       "category": "plugin",
       "official": false,
       "added": "2026-08-15",
-      "lastVerified": "2026-08-15",
+      "lastVerified": "2026-08-16",
       "verifiedAgainst": "0.1.0-rc.6",
       "status": "verified",
       "stars": 8,
       "starsUpdated": "2026-08-16",
       "tags": [
-        "capabilities"
+        "ui"
       ],
-      "pushedAt": "2026-08-16"
+      "pushedAt": "2026-08-16",
+      "npm": "dsh-plugin-smooth-stream"
     },
     {
       "name": "deepseek-harness-desktop-starsqvq",

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -21913,21 +21913,22 @@
       "pushedAt": "2026-08-13"
     },
     {
-      "name": "dsh-smooth-stream",
-      "repo": "SpookySandwich/dsh-smooth-stream",
-      "description": "DeepSeek Harness plugin: reveal assistant replies in calm fading chunks instead of token-by-token twitch.",
+      "name": "dsh-plugin-smooth-stream",
+      "repo": "SpookySandwich/dsh-plugin-smooth-stream",
+      "description": "Reveals assistant replies in fading paragraph batches instead of token-by-token; smooth scroll-follow while streaming, live summary line on thinking blocks, respects prefers-reduced-motion.",
       "category": "plugin",
       "official": false,
       "added": "2026-08-15",
-      "lastVerified": "2026-08-15",
+      "lastVerified": "2026-08-16",
       "verifiedAgainst": "0.1.0-rc.6",
       "status": "verified",
       "stars": 8,
       "starsUpdated": "2026-08-16",
       "tags": [
-        "capabilities"
+        "ui"
       ],
-      "pushedAt": "2026-08-16"
+      "pushedAt": "2026-08-16",
+      "npm": "dsh-plugin-smooth-stream"
     },
     {
       "name": "deepseek-harness-desktop-starsqvq",

--- a/docs/stats.json
+++ b/docs/stats.json
@@ -1,7 +1,7 @@
 {
   "updated": "2026-08-16",
   "plugins": 2758,
-  "npm": 581,
+  "npm": 582,
   "categories": {
     "bundle": 83,
     "plugin": 2651,

--- a/lists/tools-capabilities.md
+++ b/lists/tools-capabilities.md
@@ -4,7 +4,7 @@
 
 New things the model can do: search, browser, files, databases, devices, media.
 
-514 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
+513 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -59,7 +59,6 @@ New things the model can do: search, browser, files, databases, devices, media.
 | dsh-hdc-bridge | 8 | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | DSH-native HarmonyOS dev-assistant plugin: hdc device bridge with a live device panel, official-first versioned API docs (SDK .d.ts + offline bundled Tier-1 knowledge), and an optional DevEco CLI. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-oauth-mcp-client | 8 | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | OAuth-enabled Streamable HTTP MCP client plugin for DeepSeek Harness | 0.1.0-rc.6 (2026-08-15) |
 | dsh-playwright-browser | 8 | [Clizo1209/dsh-playwright-browser](https://github.com/Clizo1209/dsh-playwright-browser) | Semantic, multi-tab Playwright browser automation for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-14) |
-| dsh-smooth-stream | 8 | [SpookySandwich/dsh-smooth-stream](https://github.com/SpookySandwich/dsh-smooth-stream) | DeepSeek Harness plugin: reveal assistant replies in calm fading chunks instead of token-by-token twitch. | 0.1.0-rc.6 (2026-08-15) |
 | skills-creghtde | 8 | [creght-dev/skills](https://github.com/creght-dev/skills) | DeepSeek Harness bundle that registers the Creght skill pack on ctx.skills. | 0.1.0-rc.6 (2026-08-15) |
 | dsh-bash-encoding-lhh010 | 7 | [lhh010/dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) | DSH bash 输出编码自动识别插件：替换 ctx.bash，自管 spawn 收集原始字节，自动检测 UTF-16LE/UTF-8/GBK 等编码并正确解码，修复 WSL/Windows 下 bash 工具的中文乱码。 | 0.1.0-rc.6 (2026-08-15) |
 | dsh-git-identity | 7 | [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) | DSH profile bundle：git 提交固定使用环境自身作者身份（优先 gh CLI 登录账号，GitHub noreply 邮箱），GIT_AUTHOR_*/GIT_COMMITTER_* 环境变量注入压过一切 git config | 0.1.0-rc.6 (2026-08-15) |

--- a/lists/web-ui.md
+++ b/lists/web-ui.md
@@ -4,7 +4,7 @@
 
 Panels, composer upgrades, navigation, layout, mobile.
 
-286 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
+287 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -51,6 +51,7 @@ Panels, composer upgrades, navigation, layout, mobile.
 | dsh-client-ui-mobile-adapt | 8 | [Hotsteel2901/dsh-client-ui-mobile-adapt](https://github.com/Hotsteel2901/dsh-client-ui-mobile-adapt) | Mobile adaptation for the DeepSeek Harness Web GUI: single-column layout, sidebar drawer, compact header/composer, fullscreen settings, trajectory floating details, stats pill panel | 0.1.0-rc.6 (2026-08-14) |
 | dsh-fail-logger | 8 | [Areium/dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) · [npm](https://www.npmjs.com/package/dsh-fail-logger) | DSH 插件：全模式工具失败自动实录——把原生工具、PTC(Code Mode) run_code、代码内嵌工具调用的失败按错因去重计数，自动写入 skill 的机器维护区段，越用越少错。Auto-record tool failures from every execution mode into a skill's machine-maintained section (dedup + cou | 0.1.0-rc.6 (2026-08-14) |
 | dsh-maid-whale-webUI | 8 | [yunxiiQwQ/dsh-maid-whale-webUI](https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/HEAD/maid-whale-webui) | Cloud-paper DeepSeek skin for the DSH web GUI with the deepseek-drool character as a quiet page-edge mascot | 0.1.0-rc.6 (2026-08-15) |
+| dsh-plugin-smooth-stream | 8 | [SpookySandwich/dsh-plugin-smooth-stream](https://github.com/SpookySandwich/dsh-plugin-smooth-stream) · [npm](https://www.npmjs.com/package/dsh-plugin-smooth-stream) | Reveals assistant replies in fading paragraph batches instead of token-by-token; smooth scroll-follow while streaming, live summary line on thinking blocks, respects prefers-reduced-motion. | 0.1.0-rc.6 (2026-08-16) |
 | dsh-plugin-ya-workspace-sidebar | 8 | [HuanLinOTO/dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) | Two-level DSH workspace sidebar with global recent sessions and breadcrumb navigation. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-sidechain | 8 | [omdsh-dev/dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) | /side persistent side conversations and /btw one-shot side questions in an ephemeral fork that does not write main history. | 0.1.0-rc.6 (2026-08-14) |
 | deepseek-harness-zh-cn | 7 | [imlishiyuan/deepseek-harness-zh-cn](https://github.com/imlishiyuan/deepseek-harness-zh-cn) · [npm](https://www.npmjs.com/package/deepseek-harness-zh-cn) | Chinese-first plugin that makes DeepSeek Harness reason and answer in Simplified Chinese by default. | 0.1.0-rc.6 (2026-08-14) |


### PR DESCRIPTION
Updates my existing registry entry (`data/plugins.json`), regenerated with `scripts/render.mjs`.

**Rename.** `dsh-smooth-stream` → `dsh-plugin-smooth-stream`, repo `SpookySandwich/dsh-smooth-stream` → `SpookySandwich/dsh-plugin-smooth-stream`. This resolves the collision with `Laplace-bit/dsh-smooth-stream`, already listed here as `dsh-smooth-stream-laplaceb`. The old URL 301-redirects, so the current entry is stale rather than broken.

**Other field changes:**
- `npm`: added — published as `dsh-plugin-smooth-stream`
- `tags`: `capabilities` → `ui`. It is a Web GUI surface plugin; `ui` is the accurate functional area
- `description`: replaced with a more specific one — batched fade-in reveal, smooth scroll-follow while streaming, live summary line on thinking blocks, `prefers-reduced-motion` respected
- `lastVerified`: `2026-08-16`; `verifiedAgainst` unchanged at `0.1.0-rc.6`

**Verification.** Install path is a `dsh.bundle` manifest in `package.json` plus the published npm package. `dsh --profile web --dump-config` with the package installed emits the plugin's patch row against dsh `0.1.0-rc.6`, so `status: verified` is accurate as stated.

`node scripts/validate.mjs` and `node scripts/render.mjs` both pass with no drift.