### PR TITLE
Add dsh-wm world-model research bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![browse the reef](https://img.shields.io/badge/browse-the_reef-ff7a59)](https://dsh.works/awesome-dsh-plugins/)
 
-A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2758 entries across 17 functional areas, every one stating the dsh version it was last verified against.
+A spam-filtered, open-data registry of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) plugins, bundles, and skills — 2759 entries across 17 functional areas, every one stating the dsh version it was last verified against.
 
 **[Browse the reef](https://dsh.works/awesome-dsh-plugins/)** — the same registry as a filterable, sortable gallery.
 
@@ -689,7 +689,7 @@ npm packages with a `dsh.bundle` manifest: composition layers a profile boots fr
 | dsh-mermaid | 4 | [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) · [npm](https://www.npmjs.com/package/@dsh-external/dsh-mermaid) | Renders Mermaid code fences as SVG diagrams in DeepSeek Harness web conversations. | 0.1.0-rc.6 (2026-08-14) |
 | dsh-model-usage | 4 | [AKS1st/model-usage-plugin](https://github.com/AKS1st/model-usage-plugin) · [npm](https://www.npmjs.com/package/musage-stats) | Model token usage stats, cost estimates, and account balance for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-14) |
 
-<sub>Showing the 25 most-starred of 83. **[all 83 →](lists/bundles.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
+<sub>Showing the 25 most-starred of 84. **[all 84 →](lists/bundles.md)** · [gallery](https://dsh.works/awesome-dsh-plugins/) · [JSON](data/plugins.json)</sub>
 
 ### Skills
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -48920,6 +48920,21 @@
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-16"
+    },
+    {
+      "name": "dsh-wm",
+      "repo": "WayneJin0918/dsh-wm",
+      "description": "World-model research toolkit: inspect frames, name 3D / pixel / latent routes, score pred vs GT, and RSI skills / wm.yaml.",
+      "category": "bundle",
+      "official": false,
+      "added": "2026-08-17",
+      "lastVerified": "2026-08-17",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "knowledge",
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,16 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>awesome-dsh-plugins — the reef</title>
   <!-- render:meta -->
-  <meta name="description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <link rel="canonical" href="https://dsh.works/awesome-dsh-plugins/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="dshworks">
   <meta property="og:title" content="awesome-dsh-plugins — the reef">
-  <meta property="og:description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta property="og:description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <meta property="og:url" content="https://dsh.works/awesome-dsh-plugins/">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="awesome-dsh-plugins — the reef">
-  <meta name="twitter:description" content="2758 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
+  <meta name="twitter:description" content="2759 DeepSeek Harness plugins, bundles, and skills as a filterable reef: search, areas, stars, editor's picks. Not affiliated with DeepSeek.">
   <!-- /render:meta -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='%23071824'/%3E%3Cpath d='M8 22c2-6 6-9 12-9-2 3-2 5 0 8-4 2-8 2-12 1z' fill='%23ff7a59'/%3E%3Ccircle cx='22' cy='12' r='2' fill='%237ef0ff'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/plugins-embed.js
+++ b/docs/plugins-embed.js
@@ -48920,6 +48920,21 @@ window.__PLUGINS__ = {
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-16"
+    },
+    {
+      "name": "dsh-wm",
+      "repo": "WayneJin0918/dsh-wm",
+      "description": "World-model research toolkit: inspect frames, name 3D / pixel / latent routes, score pred vs GT, and RSI skills / wm.yaml.",
+      "category": "bundle",
+      "official": false,
+      "added": "2026-08-17",
+      "lastVerified": "2026-08-17",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "knowledge",
+        "observability"
+      ]
     }
   ]
 };

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -48920,6 +48920,21 @@
       "stars": 0,
       "starsUpdated": "2026-08-16",
       "pushedAt": "2026-08-16"
+    },
+    {
+      "name": "dsh-wm",
+      "repo": "WayneJin0918/dsh-wm",
+      "description": "World-model research toolkit: inspect frames, name 3D / pixel / latent routes, score pred vs GT, and RSI skills / wm.yaml.",
+      "category": "bundle",
+      "official": false,
+      "added": "2026-08-17",
+      "lastVerified": "2026-08-17",
+      "verifiedAgainst": "0.1.0-rc.6",
+      "status": "verified",
+      "tags": [
+        "knowledge",
+        "observability"
+      ]
     }
   ]
 }

--- a/docs/stats.json
+++ b/docs/stats.json
@@ -1,9 +1,9 @@
 {
   "updated": "2026-08-16",
-  "plugins": 2758,
+  "plugins": 2759,
   "npm": 582,
   "categories": {
-    "bundle": 83,
+    "bundle": 84,
     "plugin": 2651,
     "skill": 20,
     "theme": 1,

--- a/lists/bundles.md
+++ b/lists/bundles.md
@@ -4,7 +4,7 @@
 
 npm packages with a `dsh.bundle` manifest: composition layers a profile boots from.
 
-83 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
+84 entries, most-starred first. Back to the [registry README](../README.md) · [gallery](https://dsh.works/awesome-dsh-plugins/).
 
 | Name | Repo ★ | Repo | Description | Verified against |
 |---|---|---|---|---|
@@ -91,3 +91,4 @@ npm packages with a `dsh.bundle` manifest: composition layers a profile boots fr
 | git-clis-dsh | 1 | [TommyFang2077/git-clis-dsh](https://github.com/TommyFang2077/git-clis-dsh) · [npm](https://www.npmjs.com/package/@tommyfang/git-clis-dsh) | GitHub gh and Gitea tea CLI helpers for DeepSeek Harness: detect, token setup, and issue operations. | 0.1.0-rc.6 (2026-08-14) |
 | keyringseam | 1 | [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) · [npm](https://www.npmjs.com/package/keyringseam) | macOS Keychain credential provider for DeepSeek Harness. | 0.1.0-rc.6 (2026-08-14) |
 | relayloom | 1 | [fieldnote-ops/relayloom](https://github.com/fieldnote-ops/relayloom) · [npm](https://www.npmjs.com/package/relayloom) | Default-off external chat relay for DeepSeek Harness, with a DingTalk Stream compatibility adapter. | 0.1.0-rc.6 (2026-08-14) |
+| dsh-wm | - | [WayneJin0918/dsh-wm](https://github.com/WayneJin0918/dsh-wm) | World-model research toolkit: inspect frames, name 3D / pixel / latent routes, score pred vs GT, and RSI skills / wm.yaml. | 0.1.0-rc.6 (2026-08-17) |


### PR DESCRIPTION
## Summary
- Add `dsh-wm` (`WayneJin0918/dsh-wm`) as a **bundle** (`knowledge`, `observability`).
- Real install path: `package.json` `dsh.bundle` + `cordis.patch.yml`.
- Verified against **dsh 0.1.0-rc.6** on 2026-08-17: `dsh plugin --profile wm add github:WayneJin0918/dsh-wm` then `--dump-config` shows `# == dsh-wm`.
- Regenerated README via `node scripts/validate.mjs` + `node scripts/render.mjs`.

Install: `dsh plugin --profile wm add github:WayneJin0918/dsh-wm`

Made with [Cursor](https://cursor.com)